### PR TITLE
fix: unify workflow store across CLI and GUI

### DIFF
--- a/cmd/monoes/node.go
+++ b/cmd/monoes/node.go
@@ -249,9 +249,17 @@ func (sp *cliSessionProvider) GetPage(ctx context.Context, platform string, user
 		).Scan(&cookiesJSON)
 		if qErr == nil && cookiesJSON != "" {
 			var cookies []*proto.NetworkCookieParam
-			if json.Unmarshal([]byte(cookiesJSON), &cookies) == nil {
-				_ = page.SetCookies(cookies)
+			if jsonErr := json.Unmarshal([]byte(cookiesJSON), &cookies); jsonErr != nil {
+				fmt.Fprintf(os.Stderr, "  Warning: failed to unmarshal cookies: %v\n", jsonErr)
+			} else {
+				if setErr := page.SetCookies(cookies); setErr != nil {
+					fmt.Fprintf(os.Stderr, "  Warning: could not restore cookies: %v\n", setErr)
+				} else {
+					fmt.Fprintf(os.Stderr, "  Session cookies restored for %s (%d cookies)\n", platform, len(cookies))
+				}
 			}
+		} else if qErr != nil {
+			fmt.Fprintf(os.Stderr, "  No saved session for %s: %v\n", platform, qErr)
 		}
 	}
 	return page, nil

--- a/cmd/monoes/workflow.go
+++ b/cmd/monoes/workflow.go
@@ -18,10 +18,25 @@ import (
 	"github.com/nokhodian/mono-agent/internal/connections"
 	"github.com/nokhodian/mono-agent/internal/nodes"
 	"github.com/nokhodian/mono-agent/internal/scheduler"
+	"github.com/nokhodian/mono-agent/internal/storage"
 	"github.com/nokhodian/mono-agent/internal/workflow"
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 )
+
+// newHybridStore creates a HybridWorkflowStore that reads from both
+// the JSON file store (~/.monoes/workflows/) and the SQLite database.
+// This ensures workflows created by both the CLI and the Wails GUI are visible.
+func newHybridStore(db *storage.Database) *workflow.HybridWorkflowStore {
+	sqlStore := workflow.NewSQLiteWorkflowStore(db.DB)
+	fileStore, err := workflow.NewWorkflowFileStore(expandPath("~/.monoes/workflows"))
+	if err != nil {
+		// If file store can't be created, wrap SQLite-only in a hybrid shell
+		// so callers always get the same type.
+		return workflow.NewHybridWorkflowStore(nil, sqlStore)
+	}
+	return workflow.NewHybridWorkflowStore(fileStore, sqlStore)
+}
 
 // buildEngine constructs a fully wired WorkflowEngine suitable for CLI use.
 // It creates its own scheduler (no action executor or store needed for workflow triggers).
@@ -64,17 +79,7 @@ func buildEngine(cfg *globalConfig) (*workflow.WorkflowEngine, error) {
 		MaxExecHistory: 500,
 	}
 
-	// Use a hybrid store so workflows saved by the Wails app (file store)
-	// are visible to the CLI engine alongside legacy SQLite workflows.
-	wfDir := expandPath("~/.monoes/workflows")
-	fileStore, fileErr := workflow.NewWorkflowFileStore(wfDir)
-	if fileErr != nil {
-		// Fall back to pure SQLite if file store can't be created.
-		engine := workflow.NewWorkflowEngine(db.DB, sched, registry, engCfg, logger)
-		return engine, nil
-	}
-	sqlStore := workflow.NewSQLiteWorkflowStore(db.DB)
-	hybridStore := workflow.NewHybridWorkflowStore(fileStore, sqlStore)
+	hybridStore := newHybridStore(db)
 	engine := workflow.NewWorkflowEngineWithStore(hybridStore, db.DB, sched, registry, engCfg, logger)
 	return engine, nil
 }
@@ -121,13 +126,7 @@ func newWorkflowListCmd(cfg *globalConfig) *cobra.Command {
 			}
 			defer db.Close()
 
-			sqlStore := workflow.NewSQLiteWorkflowStore(db.DB)
-			var store interface {
-				ListWorkflows(context.Context) ([]workflow.Workflow, error)
-			} = sqlStore
-			if fileStore, ferr := workflow.NewWorkflowFileStore(expandPath("~/.monoes/workflows")); ferr == nil {
-				store = workflow.NewHybridWorkflowStore(fileStore, sqlStore)
-			}
+			store := newHybridStore(db)
 			ctx := context.Background()
 
 			workflows, err := store.ListWorkflows(ctx)
@@ -172,7 +171,7 @@ func newWorkflowGetCmd(cfg *globalConfig) *cobra.Command {
 			}
 			defer db.Close()
 
-			store := workflow.NewSQLiteWorkflowStore(db.DB)
+			store := newHybridStore(db)
 			ctx := context.Background()
 
 			wf, err := store.GetWorkflow(ctx, args[0])
@@ -370,7 +369,7 @@ func newWorkflowExecutionsCmd(cfg *globalConfig) *cobra.Command {
 			}
 			defer db.Close()
 
-			store := workflow.NewSQLiteWorkflowStore(db.DB)
+			store := newHybridStore(db)
 			ctx := context.Background()
 
 			executions, err := store.ListExecutions(ctx, args[0], limit)
@@ -435,7 +434,7 @@ func newWorkflowCreateCmd(cfg *globalConfig) *cobra.Command {
 				UpdatedAt:   now,
 			}
 
-			store := workflow.NewSQLiteWorkflowStore(db.DB)
+			store := newHybridStore(db)
 			ctx := context.Background()
 			if err := store.CreateWorkflow(ctx, wf); err != nil {
 				return fmt.Errorf("create workflow: %w", err)
@@ -493,7 +492,7 @@ func newWorkflowImportCmd(cfg *globalConfig) *cobra.Command {
 			}
 			defer db.Close()
 
-			store := workflow.NewSQLiteWorkflowStore(db.DB)
+			store := newHybridStore(db)
 			ctx := context.Background()
 
 			now := time.Now().UTC()
@@ -563,7 +562,7 @@ func newWorkflowExportCmd(cfg *globalConfig) *cobra.Command {
 			}
 			defer db.Close()
 
-			store := workflow.NewSQLiteWorkflowStore(db.DB)
+			store := newHybridStore(db)
 			ctx := context.Background()
 
 			wf, err := store.GetWorkflow(ctx, args[0])
@@ -633,7 +632,7 @@ func newWorkflowNodeAddCmd(cfg *globalConfig) *cobra.Command {
 			}
 			defer db.Close()
 
-			store := workflow.NewSQLiteWorkflowStore(db.DB)
+			store := newHybridStore(db)
 			ctx := context.Background()
 
 			// Ensure workflow exists.
@@ -706,7 +705,7 @@ func newWorkflowNodeListCmd(cfg *globalConfig) *cobra.Command {
 			}
 			defer db.Close()
 
-			store := workflow.NewSQLiteWorkflowStore(db.DB)
+			store := newHybridStore(db)
 			ctx := context.Background()
 
 			wf, err := store.GetWorkflow(ctx, args[0])
@@ -755,7 +754,7 @@ func newWorkflowNodeSetCmd(cfg *globalConfig) *cobra.Command {
 			}
 			defer db.Close()
 
-			store := workflow.NewSQLiteWorkflowStore(db.DB)
+			store := newHybridStore(db)
 			ctx := context.Background()
 
 			wf, err := store.GetWorkflow(ctx, workflowID)
@@ -830,7 +829,7 @@ func newWorkflowNodeRemoveCmd(cfg *globalConfig) *cobra.Command {
 			}
 			defer db.Close()
 
-			store := workflow.NewSQLiteWorkflowStore(db.DB)
+			store := newHybridStore(db)
 			ctx := context.Background()
 
 			wf, err := store.GetWorkflow(ctx, workflowID)
@@ -907,7 +906,7 @@ func newWorkflowConnectCmd(cfg *globalConfig) *cobra.Command {
 			}
 			defer db.Close()
 
-			store := workflow.NewSQLiteWorkflowStore(db.DB)
+			store := newHybridStore(db)
 			ctx := context.Background()
 
 			wf, err := store.GetWorkflow(ctx, workflowID)
@@ -961,7 +960,7 @@ func newWorkflowDisconnectCmd(cfg *globalConfig) *cobra.Command {
 			}
 			defer db.Close()
 
-			store := workflow.NewSQLiteWorkflowStore(db.DB)
+			store := newHybridStore(db)
 			ctx := context.Background()
 
 			wf, err := store.GetWorkflow(ctx, workflowID)

--- a/data/actions/linkedin/find_by_keyword.json
+++ b/data/actions/linkedin/find_by_keyword.json
@@ -80,15 +80,19 @@
     {
       "id": "find_search_results",
       "type": "find_element",
-      "configKey": "search_result_container",
+      "selector": "[data-testid='lazy-column']",
+      "alternatives": [
+        "div[role='list']",
+        "search_result_container"
+      ],
       "timeout": 15
     },
     {
       "id": "extract_people_data",
       "type": "extract_multiple",
-      "selector": ".entity-result__title-text a[href*='/in/']",
+      "selector": "div[role='list'] > [data-display-contents] > a[href*='/in/']",
       "alternatives": [
-        "//ul[contains(@class,'reusable-search__entity-result-list')]//a[contains(@href,'/in/')]",
+        "div[role='list'] a[href*='/in/'][componentkey]",
         "people"
       ],
       "onSuccess": {

--- a/internal/workflow/hybrid_store.go
+++ b/internal/workflow/hybrid_store.go
@@ -8,51 +8,59 @@ import (
 // WorkflowFileStore (JSON files) and all execution/credential operations to a
 // SQLiteWorkflowStore.
 //
-// This is the store used by the CLI engine so that workflows created in the
-// Wails app (stored as JSON files) are visible to `monoes workflow run`.
+// If the file store is nil, all workflow CRUD falls back to SQLite only.
+// This is the canonical store — used by both the CLI and the Wails GUI.
 type HybridWorkflowStore struct {
 	files *WorkflowFileStore
 	sql   *SQLiteWorkflowStore
 }
 
 // NewHybridWorkflowStore creates a HybridWorkflowStore.
+// files may be nil, in which case all workflow CRUD uses SQLite only.
 func NewHybridWorkflowStore(files *WorkflowFileStore, sql *SQLiteWorkflowStore) *HybridWorkflowStore {
 	return &HybridWorkflowStore{files: files, sql: sql}
 }
 
 // ---------------------------------------------------------------------------
-// Workflow CRUD — delegated to file store
+// Workflow CRUD — file store preferred, SQLite fallback
 // ---------------------------------------------------------------------------
 
 func (h *HybridWorkflowStore) CreateWorkflow(ctx context.Context, w *Workflow) error {
-	return h.files.SaveWorkflow(ctx, w)
+	if h.files != nil {
+		return h.files.SaveWorkflow(ctx, w)
+	}
+	return h.sql.CreateWorkflow(ctx, w)
 }
 
 func (h *HybridWorkflowStore) GetWorkflow(ctx context.Context, id string) (*Workflow, error) {
 	// Try file store first (Wails-created workflows live here).
-	wf, err := h.files.GetWorkflow(ctx, id)
-	if err != nil {
-		return nil, err
-	}
-	if wf != nil {
-		return wf, nil
+	if h.files != nil {
+		wf, err := h.files.GetWorkflow(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if wf != nil {
+			return wf, nil
+		}
 	}
 	// Fall back to SQLite (imported/legacy workflows).
 	return h.sql.GetWorkflow(ctx, id)
 }
 
 func (h *HybridWorkflowStore) ListWorkflows(ctx context.Context) ([]Workflow, error) {
-	filePtrs, err := h.files.ListWorkflows(ctx)
-	if err != nil {
-		return nil, err
-	}
+	seen := make(map[string]bool)
+	var result []Workflow
 
-	// Collect file-store IDs so we can de-duplicate.
-	seen := make(map[string]bool, len(filePtrs))
-	result := make([]Workflow, 0, len(filePtrs))
-	for _, wf := range filePtrs {
-		seen[wf.ID] = true
-		result = append(result, *wf)
+	// Collect file-store workflows first.
+	if h.files != nil {
+		filePtrs, err := h.files.ListWorkflows(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, wf := range filePtrs {
+			seen[wf.ID] = true
+			result = append(result, *wf)
+		}
 	}
 
 	// Append SQLite workflows not already present in the file store.
@@ -69,21 +77,36 @@ func (h *HybridWorkflowStore) ListWorkflows(ctx context.Context) ([]Workflow, er
 }
 
 func (h *HybridWorkflowStore) UpdateWorkflow(ctx context.Context, w *Workflow) error {
-	return h.files.SaveWorkflow(ctx, w)
+	if h.files != nil {
+		return h.files.SaveWorkflow(ctx, w)
+	}
+	return h.sql.UpdateWorkflow(ctx, w)
+}
+
+// SaveWorkflow writes a workflow to the file store (create or update).
+func (h *HybridWorkflowStore) SaveWorkflow(ctx context.Context, w *Workflow) error {
+	if h.files != nil {
+		return h.files.SaveWorkflow(ctx, w)
+	}
+	return h.sql.UpdateWorkflow(ctx, w)
 }
 
 func (h *HybridWorkflowStore) DeleteWorkflow(ctx context.Context, id string) error {
-	_ = h.files.DeleteWorkflow(ctx, id) // ignore not-found
-	_ = h.sql.DeleteWorkflow(ctx, id)   // ignore not-found
+	if h.files != nil {
+		_ = h.files.DeleteWorkflow(ctx, id) // ignore not-found
+	}
+	_ = h.sql.DeleteWorkflow(ctx, id) // ignore not-found
 	return nil
 }
 
 func (h *HybridWorkflowStore) SetWorkflowActive(ctx context.Context, id string, active bool) error {
 	// Try to update in file store.
-	wf, err := h.files.GetWorkflow(ctx, id)
-	if err == nil && wf != nil {
-		wf.IsActive = active
-		return h.files.SaveWorkflow(ctx, wf)
+	if h.files != nil {
+		wf, err := h.files.GetWorkflow(ctx, id)
+		if err == nil && wf != nil {
+			wf.IsActive = active
+			return h.files.SaveWorkflow(ctx, wf)
+		}
 	}
 	return h.sql.SetWorkflowActive(ctx, id, active)
 }
@@ -108,12 +131,14 @@ func (h *HybridWorkflowStore) CreateExecution(ctx context.Context, e *WorkflowEx
 	// Ensure the workflow row exists in SQLite (FK constraint).
 	// If the workflow lives only in the file store, mirror it to SQLite first.
 	if existing, err := h.sql.GetWorkflow(ctx, e.WorkflowID); err == nil && existing == nil {
-		if wf, ferr := h.files.GetWorkflow(ctx, e.WorkflowID); ferr == nil && wf != nil {
-			// Insert a minimal stub row — only metadata, no nodes/connections.
-			stub := *wf
-			stub.Nodes = nil
-			stub.Connections = nil
-			_ = h.sql.CreateWorkflow(ctx, &stub)
+		if h.files != nil {
+			if wf, ferr := h.files.GetWorkflow(ctx, e.WorkflowID); ferr == nil && wf != nil {
+				// Insert a minimal stub row — only metadata, no nodes/connections.
+				stub := *wf
+				stub.Nodes = nil
+				stub.Connections = nil
+				_ = h.sql.CreateWorkflow(ctx, &stub)
+			}
 		}
 	}
 	return h.sql.CreateExecution(ctx, e)

--- a/wails-app/app.go
+++ b/wails-app/app.go
@@ -45,7 +45,7 @@ type App struct {
 	aiStore     *ai.AIStore
 	chatService *aichat.ChatService
 	cfgMgr      action.ConfigInterface
-	wfStore     *workflow.WorkflowFileStore
+	wfStore     *workflow.HybridWorkflowStore
 }
 
 // NewApp creates the App instance.
@@ -66,13 +66,15 @@ func (a *App) startup(ctx context.Context) {
 	}
 	a.db = db
 
-	// Initialize workflow file store.
+	// Initialize workflow hybrid store (file + SQLite) so workflows created
+	// by both the GUI and the CLI are visible.
 	wfDir := filepath.Join(os.Getenv("HOME"), ".monoes", "workflows")
-	wfStore, wfErr := workflow.NewWorkflowFileStore(wfDir)
+	fileStore, wfErr := workflow.NewWorkflowFileStore(wfDir)
 	if wfErr != nil {
 		fmt.Printf("workflow file store init error: %v\n", wfErr)
 	} else {
-		a.wfStore = wfStore
+		sqlStore := workflow.NewSQLiteWorkflowStore(db)
+		a.wfStore = workflow.NewHybridWorkflowStore(fileStore, sqlStore)
 	}
 
 	// Initialize connections manager.
@@ -1429,15 +1431,15 @@ func (a *App) ListWorkflows() ([]WorkflowSummary, error) {
 		return nil, err
 	}
 	summaries := make([]WorkflowSummary, 0, len(wfs))
-	for _, wf := range wfs {
+	for i := range wfs {
 		summaries = append(summaries, WorkflowSummary{
-			ID:          wf.ID,
-			Name:        wf.Name,
-			Description: wf.Description,
-			IsActive:    wf.IsActive,
-			Version:     wf.Version,
-			CreatedAt:   wf.CreatedAt.Format(time.RFC3339),
-			UpdatedAt:   wf.UpdatedAt.Format(time.RFC3339),
+			ID:          wfs[i].ID,
+			Name:        wfs[i].Name,
+			Description: wfs[i].Description,
+			IsActive:    wfs[i].IsActive,
+			Version:     wfs[i].Version,
+			CreatedAt:   wfs[i].CreatedAt.Format(time.RFC3339),
+			UpdatedAt:   wfs[i].UpdatedAt.Format(time.RFC3339),
 		})
 	}
 	return summaries, nil


### PR DESCRIPTION
## Summary
- **Unified workflow storage**: Replace all 13 SQLite-only workflow store usages in CLI with `HybridWorkflowStore` (file + SQLite), and switch the Wails GUI from file-only to hybrid. Workflows created in either the CLI or GUI are now always visible in both.
- **Nil-safe HybridWorkflowStore**: All CRUD methods now gracefully fall back to SQLite when the file store is unavailable.
- **Updated LinkedIn selectors**: `find_by_keyword.json` selectors updated for LinkedIn's current DOM (hashed class names replaced with stable `data-testid` and `role` attributes).
- **Better cookie error logging**: Session cookie restoration in `cliSessionProvider.GetPage()` now logs errors instead of silently discarding them.

## Test plan
- [ ] `monoes workflow list` shows workflows from both SQLite and `~/.monoes/workflows/`
- [ ] `monoes workflow create` + verify it appears in the Wails GUI
- [ ] Create a workflow in the GUI + verify `monoes workflow get <id>` works from CLI
- [ ] `monoes workflow run` works for workflows from either store
- [ ] `monoes node run linkedin.find_by_keyword --config '{"keyword":"test","max":5}'` extracts results with updated selectors

🤖 Generated with [Claude Code](https://claude.com/claude-code)