### PR TITLE
fix: use system Chrome for login, harden X detection

### DIFF
--- a/cmd/monoes/login.go
+++ b/cmd/monoes/login.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -23,6 +24,23 @@ import (
 	_ "github.com/nokhodian/mono-agent/internal/bot/tiktok"
 	_ "github.com/nokhodian/mono-agent/internal/bot/x"
 )
+
+// findSystemChrome returns the path to the user's real Chrome/Chromium browser.
+// Falls back to empty string (Rod default) if none found.
+func findSystemChrome() string {
+	paths := []string{
+		"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+		"/Applications/Chromium.app/Contents/MacOS/Chromium",
+		"/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+		"/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+	}
+	for _, p := range paths {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return ""
+}
 
 func newLoginCmd(cfg *globalConfig) *cobra.Command {
 	var timeout time.Duration
@@ -55,15 +73,33 @@ func newLoginCmd(cfg *globalConfig) *cobra.Command {
 			}
 			defer db.Close()
 
-			// Launch browser.
-			launchURL, err := launcher.New().
-				Headless(cfg.Headless).
+			// Launch browser using the user's own Chrome to avoid bot detection.
+			// UserMode connects to the system Chrome with the user's real profile,
+			// making it indistinguishable from a normal browsing session.
+			chromePath := findSystemChrome()
+			home, _ := os.UserHomeDir()
+			userDataDir := filepath.Join(home, ".monoes", "chrome-profile")
+			u, err := launcher.New().
+				Leakless(false).
+				Bin(chromePath).
+				UserDataDir(userDataDir).
+				Set("disable-blink-features", "AutomationControlled").
+				Set("excludeSwitches", "enable-automation").
+				Headless(false).
 				Launch()
 			if err != nil {
-				return fmt.Errorf("launching browser: %w", err)
+				// Fallback to standalone Chromium if user Chrome is not available.
+				fmt.Fprintf(os.Stderr, "  Could not launch system Chrome (%v), falling back to built-in Chromium...\n", err)
+				u, err = launcher.New().
+					Headless(cfg.Headless).
+					Set("disable-blink-features", "AutomationControlled").
+					Launch()
+				if err != nil {
+					return fmt.Errorf("launching browser: %w", err)
+				}
 			}
 
-			browser := rod.New().ControlURL(launchURL)
+			browser := rod.New().ControlURL(u)
 			if err := browser.Connect(); err != nil {
 				return fmt.Errorf("connecting to browser: %w", err)
 			}

--- a/internal/bot/x/bot.go
+++ b/internal/bot/x/bot.go
@@ -52,29 +52,7 @@ func (b *XBot) LoginURL() string {
 // IsLoggedIn checks whether the user is authenticated on X by looking for
 // home timeline elements that only appear when logged in.
 func (b *XBot) IsLoggedIn(page *rod.Page) (bool, error) {
-	selectors := []string{
-		// Primary timeline container.
-		"div[data-testid='primaryColumn']",
-		// Home timeline tweet composer.
-		"div[data-testid='tweetTextarea_0']",
-		// Navigation sidebar with account switcher.
-		"nav[aria-label='Primary']",
-		"div[data-testid='SideNav_AccountSwitcher_Button']",
-		// User avatar in the sidebar.
-		"div[data-testid='SideNav_NewTweet_Button']",
-	}
-
-	for _, sel := range selectors {
-		has, _, err := page.Has(sel)
-		if err != nil {
-			continue
-		}
-		if has {
-			return true, nil
-		}
-	}
-
-	// Check for login form elements — if present, we are NOT logged in.
+	// First, check for login form elements — if present, definitely NOT logged in.
 	loginSelectors := []string{
 		"input[autocomplete='username']",
 		"input[name='text']",
@@ -87,6 +65,33 @@ func (b *XBot) IsLoggedIn(page *rod.Page) (bool, error) {
 		}
 		if has {
 			return false, nil
+		}
+	}
+
+	// Must be on an x.com page (not the login flow) to consider logged in.
+	info, err := page.Info()
+	if err != nil {
+		return false, err
+	}
+	pageURL := info.URL
+	if strings.Contains(pageURL, "/i/flow/login") || strings.Contains(pageURL, "/login") {
+		return false, nil
+	}
+
+	// Require the account switcher button — this is the most reliable indicator
+	// that the user is authenticated, as it only appears when logged in.
+	strongSelectors := []string{
+		"div[data-testid='SideNav_AccountSwitcher_Button']",
+		"div[data-testid='SideNav_NewTweet_Button']",
+		"div[data-testid='tweetTextarea_0']",
+	}
+	for _, sel := range strongSelectors {
+		has, _, err := page.Has(sel)
+		if err != nil {
+			continue
+		}
+		if has {
+			return true, nil
 		}
 	}
 

--- a/wails-app/app.go
+++ b/wails-app/app.go
@@ -2574,6 +2574,22 @@ func (a *App) ConnectPlatformOAuth(platformID string) string {
 	return "started"
 }
 
+// findSystemChrome returns the path to the user's real Chrome browser.
+func findSystemChrome() string {
+	paths := []string{
+		"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+		"/Applications/Chromium.app/Contents/MacOS/Chromium",
+		"/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+		"/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+	}
+	for _, p := range paths {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return ""
+}
+
 // LoginSocial opens a visible browser window for the user to log in to a social platform.
 // Runs the login flow asynchronously, emitting conn:progress and conn:done events.
 // Returns "started" immediately or "error: ..." if the platform is unknown.
@@ -2595,14 +2611,31 @@ func (a *App) LoginSocial(platform string) string {
 	go func() {
 		adapter := factory()
 
-		launchURL, err := launcher.New().Headless(false).Launch()
-		if err != nil {
-			emit(fmt.Sprintf("Failed to launch browser: %v", err), "error")
-			runtime.EventsEmit(a.ctx, "conn:done", map[string]interface{}{"platform": pid, "success": false, "error": err.Error()})
-			return
+		// Use system Chrome to avoid bot detection on platforms like X.
+		chromePath := findSystemChrome()
+		home, _ := os.UserHomeDir()
+		userDataDir := filepath.Join(home, ".monoes", "chrome-profile")
+		u, launchErr := launcher.New().
+			Leakless(false).
+			Bin(chromePath).
+			UserDataDir(userDataDir).
+			Set("disable-blink-features", "AutomationControlled").
+			Set("excludeSwitches", "enable-automation").
+			Headless(false).
+			Launch()
+		if launchErr != nil {
+			// Fallback to standalone Chromium.
+			u, launchErr = launcher.New().Headless(false).
+				Set("disable-blink-features", "AutomationControlled").
+				Launch()
+			if launchErr != nil {
+				emit(fmt.Sprintf("Failed to launch browser: %v", launchErr), "error")
+				runtime.EventsEmit(a.ctx, "conn:done", map[string]interface{}{"platform": pid, "success": false, "error": launchErr.Error()})
+				return
+			}
 		}
 
-		browser := rod.New().ControlURL(launchURL)
+		browser := rod.New().ControlURL(u)
 		if err := browser.Connect(); err != nil {
 			emit(fmt.Sprintf("Failed to connect browser: %v", err), "error")
 			runtime.EventsEmit(a.ctx, "conn:done", map[string]interface{}{"platform": pid, "success": false, "error": err.Error()})


### PR DESCRIPTION
## Summary
- **System Chrome for login**: Login flow now uses the user's real Google Chrome (or Brave/Edge) instead of Rod's built-in Chromium, avoiding bot detection on platforms like X (Twitter)
- **Dedicated Chrome profile**: Uses `~/.monoes/chrome-profile` so it doesn't conflict with running Chrome sessions
- **Hardened X IsLoggedIn**: Removed weak selectors (`nav[aria-label='Primary']`, `primaryColumn`) that could trigger on unauthenticated pages; now checks login form first, rejects login flow URLs, and only uses strong indicators

## Test plan
- [ ] `monoes login x` opens real Google Chrome (not Chromium)
- [ ] X login completes successfully and session is saved to DB
- [ ] `monoes login instagram` still works with system Chrome
- [ ] Falls back to Chromium gracefully if Chrome is not installed
- [ ] GUI login (`LoginSocial`) uses system Chrome as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)