### PR TITLE
fix(linkedin): save find_by_keyword results to people table

### DIFF
--- a/cmd/monoagentcli/run.go
+++ b/cmd/monoagentcli/run.go
@@ -14,6 +14,7 @@ import (
 	"monoagent/internal/bot"
 	browserpkg "monoagent/internal/browser"
 	"monoagent/internal/config"
+	"monoagent/internal/nodes"
 	"monoagent/internal/storage"
 	"monoagent/internal/util"
 	"github.com/olekukonko/tablewriter"
@@ -679,7 +680,15 @@ func executeAction(
 
 		// Save extracted data to people table.
 		if extracted > 0 {
-			if saveErr := sa.SaveExtractedData(act.ID, result.ExtractedItems); saveErr != nil {
+			// stepExtractMultiple (list-scrape steps like find_by_keyword) only
+			// populates generic "text"/"href" keys. Normalize to the "platform"/
+			// "url"/"full_name" fields SaveExtractedData expects — otherwise every
+			// row is silently skipped for lacking a resolvable username.
+			normalized := make([]map[string]interface{}, len(result.ExtractedItems))
+			for i, item := range result.ExtractedItems {
+				normalized[i] = nodes.NormalizeBrowserItem(item, act.TargetPlatform)
+			}
+			if saveErr := sa.SaveExtractedData(act.ID, normalized); saveErr != nil {
 				fmt.Fprintf(os.Stderr, "  Warning: failed to save some extracted data: %v\n", saveErr)
 			} else {
 				fmt.Fprintf(os.Stderr, "  Saved %d extracted profile(s) to database\n", extracted)

--- a/internal/nodes/browser_adapter.go
+++ b/internal/nodes/browser_adapter.go
@@ -216,7 +216,7 @@ func (b *BrowserNode) Execute(ctx context.Context, input workflow.NodeInput, con
 		// Overlay each step's result in order so the last step wins for any
 		// key that appears in multiple steps.
 		for _, raw := range result.ExtractedItems {
-			for k, v := range normalizeBrowserItem(raw, b.platform) {
+			for k, v := range NormalizeBrowserItem(raw, b.platform) {
 				merged[k] = v
 			}
 		}
@@ -237,13 +237,13 @@ func (b *BrowserNode) Execute(ctx context.Context, input workflow.NodeInput, con
 	}, nil
 }
 
-// normalizeBrowserItem enriches a raw extracted item with structured fields.
+// NormalizeBrowserItem enriches a raw extracted item with structured fields.
 //
 // stepExtractMultiple produces items with generic keys: "text" (visible text of
 // the DOM element) and "href" (the element's href attribute if present).
 // This function maps those to the canonical people fields that people.save
 // and SaveExtractedData expect.
-func normalizeBrowserItem(raw map[string]interface{}, platform string) map[string]interface{} {
+func NormalizeBrowserItem(raw map[string]interface{}, platform string) map[string]interface{} {
 	out := make(map[string]interface{}, len(raw)+4)
 	for k, v := range raw {
 		out[k] = v

--- a/internal/nodes/browser_adapter_test.go
+++ b/internal/nodes/browser_adapter_test.go
@@ -7,7 +7,7 @@ func TestNormalizeBrowserItem(t *testing.T) {
 		"text": "Alice Wonderland\nCTO at StartupCo\nBerlin",
 		"href": "https://www.linkedin.com/in/alice-wonderland/",
 	}
-	out := normalizeBrowserItem(raw, "linkedin")
+	out := NormalizeBrowserItem(raw, "linkedin")
 
 	cases := []struct {
 		key  string
@@ -22,7 +22,7 @@ func TestNormalizeBrowserItem(t *testing.T) {
 	for _, c := range cases {
 		got, _ := out[c.key].(string)
 		if got != c.want {
-			t.Errorf("normalizeBrowserItem[%q]: want %q, got %q", c.key, c.want, got)
+			t.Errorf("NormalizeBrowserItem[%q]: want %q, got %q", c.key, c.want, got)
 		}
 	}
 }
@@ -34,7 +34,7 @@ func TestNormalizeBrowserItem_PreservesExistingFields(t *testing.T) {
 		"platform":    "instagram",
 		"href":        "https://other.url/",
 	}
-	out := normalizeBrowserItem(raw, "linkedin")
+	out := NormalizeBrowserItem(raw, "linkedin")
 
 	// Should NOT overwrite existing values.
 	if out["profile_url"] != "https://existing.url/" {


### PR DESCRIPTION
## Summary
- `SaveExtractedData` (`cmd/monoagentcli/run.go`) expects each extracted item to carry `platform`/`url`/`full_name` keys, but `stepExtractMultiple` — used by list-scrape actions like `linkedin.find_by_keyword` — only ever produces generic `text`/`href` keys. Every row was silently skipped for lacking a resolvable username, while the CLI still printed `Saved N extracted profile(s) to database`, masking total data loss.
- Export `NormalizeBrowserItem` (previously private to the workflow-node path in `internal/nodes/browser_adapter.go`) and reuse it in `run`'s `executeAction`, so both the CLI `run` path and the workflow-node path normalize scraped items the same way before persisting.

Found this while running `monoagentcli run <find_by_keyword-action-id> --param maxResultsCount=10` for LinkedIn — action reported 10/10 succeeded and "Saved 10 extracted profile(s)", but `people list` came back empty. Verified the fix end-to-end: same action now correctly saves all 10 people with resolved usernames and profile URLs.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/nodes/... ./cmd/monoagentcli/...`
- [x] Manually ran `monoagentcli action create --type find_by_keyword --platform linkedin --keyword "..."` + `monoagentcli run <id> --param maxResultsCount=10`, confirmed `monoagentcli people list` now shows all 10 saved profiles (previously 0)