### PR TITLE
fix(gui): suppress visible console windows on Windows subprocesses

### DIFF
--- a/wails-app/app.go
+++ b/wails-app/app.go
@@ -849,6 +849,7 @@ func (a *App) ExportData() (*ExportResult, error) {
 		return &ExportResult{Cancelled: true}, nil
 	}
 	cmd := exec.CommandContext(a.ctx, cliBin, "--profile", a.getActiveProfileID(), "--json", "export", "--output-dir", dir)
+	hideWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		var ee *exec.ExitError
@@ -1034,6 +1035,7 @@ func (a *App) bootstrapProfileMonograph(profileID string) {
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 		cmd := exec.CommandContext(ctx, bin, "monograph", "build", "--path", profiledir.MonomindDir(db, profileID))
+		hideWindow(cmd)
 		if err := cmd.Run(); err != nil {
 			a.emitLog("SYSTEM", "WARN", fmt.Sprintf("profile %s: monograph bootstrap: %v", profileID, err))
 		}
@@ -1068,7 +1070,9 @@ func (a *App) RevealProfileFolder(profileID string) error {
 // per-GOOS command selection without spawning a real GUI file manager.
 func revealFolder(dir string) error {
 	name, args := revealFolderCommand(goruntime.GOOS, dir)
-	err := exec.Command(name, args...).Run()
+	cmd := exec.Command(name, args...)
+	hideWindow(cmd)
+	err := cmd.Run()
 	if err == nil {
 		return nil
 	}

--- a/wails-app/app_applications.go
+++ b/wails-app/app_applications.go
@@ -27,6 +27,7 @@ func (a *App) runMonoCLI(stdin string, result interface{}, args ...string) error
 	}
 	fullArgs := append([]string{"--profile", a.getActiveProfileID(), "--json"}, args...)
 	cmd := exec.CommandContext(a.ctx, cliBin, fullArgs...)
+	hideWindow(cmd)
 	if stdin != "" {
 		cmd.Stdin = strings.NewReader(stdin)
 	}

--- a/wails-app/app_connections.go
+++ b/wails-app/app_connections.go
@@ -387,6 +387,7 @@ func (a *App) LoginSocial(platform string) string {
 
 	go func() {
 		cmd := exec.CommandContext(a.ctx, cliBin, "--profile", a.getActiveProfileID(), "login", pid)
+		hideWindow(cmd)
 		stderr, _ := cmd.StderrPipe()
 
 		if startErr := cmd.Start(); startErr != nil {
@@ -433,6 +434,7 @@ func (a *App) ConfirmSocialLogin(platform string) string {
 
 	go func() {
 		cmd := exec.CommandContext(a.ctx, cliBin, "--profile", a.getActiveProfileID(), "login", "confirm", pid)
+		hideWindow(cmd)
 		stdout, _ := cmd.StdoutPipe()
 		stderr, _ := cmd.StderrPipe()
 

--- a/wails-app/app_files.go
+++ b/wails-app/app_files.go
@@ -74,7 +74,9 @@ func (a *App) OpenPathWithOS(path string) error {
 	// stay open indefinitely, so this only reports launch failures (missing
 	// binary, ...), not the opened app's own exit code — same fire-and-forget
 	// shape as app_update.go's install scripts.
-	return exec.Command(name, args...).Start()
+	cmd := exec.Command(name, args...)
+	hideWindow(cmd)
+	return cmd.Start()
 }
 
 // openFileCommand returns the OS-appropriate command name and arguments to

--- a/wails-app/app_monomind_init.go
+++ b/wails-app/app_monomind_init.go
@@ -80,6 +80,7 @@ func (a *App) InitializeMonomindProfile() string {
 		// but CI=true guarantees every prompt path treats this as
 		// non-interactive even if that check changes upstream.
 		cmd := exec.CommandContext(ctx, bin, "init", "--yes", "--no-watch", "--no-install")
+		hideWindow(cmd)
 		cmd.Dir = root // monomind init has no --project flag and does not honor MONOMIND_CWD — cwd is the only way to scope it
 		cmd.Env = append(os.Environ(), "CI=true")
 
@@ -136,6 +137,7 @@ func (a *App) registerClaudeCodeProject(root string) {
 	ctx, cancel := context.WithTimeout(a.ctx, 60*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, claudeBin, "-p", "monomind initialized")
+	hideWindow(cmd)
 	cmd.Dir = root
 	if err := cmd.Run(); err != nil {
 		a.emitMonomindInitEvent("line", "(claude CLI registration step failed, non-fatal: "+err.Error()+")")

--- a/wails-app/app_nodes.go
+++ b/wails-app/app_nodes.go
@@ -383,6 +383,7 @@ func (a *App) RunNode(req NodeRunRequest) NodeRunResult {
 		args = append(args, "--credential", credID)
 	}
 	cmd := exec.Command(cliBin, args...)
+	hideWindow(cmd)
 	cmd.Stdin = bytes.NewReader(payload)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/wails-app/app_orgs.go
+++ b/wails-app/app_orgs.go
@@ -77,6 +77,7 @@ func (a *App) runOrgCLI(args ...string) string {
 	a.emitLog("ORG", "INFO", fmt.Sprintf("$ %s %s%s", cliBin, strings.Join(fullArgs, " "), logSuffix))
 	startedAt := time.Now()
 	cmd := exec.CommandContext(ctx, cliBin, fullArgs...)
+	hideWindow(cmd)
 	out, err := cmd.Output()
 	elapsed := time.Since(startedAt).Round(time.Millisecond)
 	if err != nil {

--- a/wails-app/app_orgs_design.go
+++ b/wails-app/app_orgs_design.go
@@ -330,6 +330,7 @@ func (a *App) ReloadOrg(orgName string) string {
 		args = append(args, "--project", root)
 	}
 	cmd := exec.Command(cliBin, args...)
+	hideWindow(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return aiError(fmt.Errorf("%s", strings.TrimSpace(string(out))))
@@ -415,6 +416,7 @@ func (a *App) cliValidate(root, name string) error {
 		args = append(args, "--project", root)
 	}
 	cmd := exec.Command(cliBin, args...)
+	hideWindow(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%s", strings.TrimSpace(string(out)))

--- a/wails-app/app_update.go
+++ b/wails-app/app_update.go
@@ -179,7 +179,9 @@ func (a *App) updateAppWindows(exe, tmpPath, newVersion string) UpdateResult {
 		return UpdateResult{Error: fmt.Sprintf("write bat: %v", err)}
 	}
 
-	if err := exec.Command("cmd.exe", "/C", batPath).Start(); err != nil { //nolint:gosec
+	cmd := exec.Command("cmd.exe", "/C", batPath) //nolint:gosec
+	hideWindow(cmd)
+	if err := cmd.Start(); err != nil {
 		os.Remove(tmpPath)
 		os.Remove(batPath)
 		return UpdateResult{Error: fmt.Sprintf("start update script: %v", err)}

--- a/wails-app/app_vault.go
+++ b/wails-app/app_vault.go
@@ -144,6 +144,7 @@ func (a *App) runVaultCLI(stdin string, result interface{}, args ...string) erro
 	}
 	fullArgs := append([]string{"--profile", a.getActiveProfileID(), "--json", "secret"}, args...)
 	cmd := exec.CommandContext(a.ctx, cliBin, fullArgs...)
+	hideWindow(cmd)
 	if stdin != "" {
 		cmd.Stdin = strings.NewReader(stdin)
 	}

--- a/wails-app/app_workflows.go
+++ b/wails-app/app_workflows.go
@@ -474,6 +474,7 @@ func (a *App) ImportWorkflow(jsonOrPath string) (*WorkflowImportResult, error) {
 		ctx = context.Background()
 	}
 	cmd := exec.CommandContext(ctx, cliBin, "--profile", a.getActiveProfileID(), "--json", "workflow", "import")
+	hideWindow(cmd)
 	cmd.Stdin = bytes.NewReader(raw)
 	out, err := cmd.Output()
 	if err != nil {
@@ -536,6 +537,7 @@ func (a *App) RunWorkflow(id string) error {
 	a.emitLog("WORKFLOW", "INFO", fmt.Sprintf("Starting workflow %s", id))
 
 	cmd := exec.CommandContext(a.ctx, cliBin, "--profile", a.getActiveProfileID(), "workflow", "run", id)
+	hideWindow(cmd)
 	stdout, _ := cmd.StdoutPipe()
 	stderr, _ := cmd.StderrPipe()
 

--- a/wails-app/proc_unix.go
+++ b/wails-app/proc_unix.go
@@ -13,6 +13,9 @@ import (
 	"syscall"
 )
 
+// hideWindow is a no-op on non-Windows platforms.
+func hideWindow(cmd *exec.Cmd) {}
+
 // setChatProcessGroup isolates the chat subprocess (monoagentcli → monomind
 // → agent CLI) in its own process group so a UI stop reaps the whole tree.
 func setChatProcessGroup(cmd *exec.Cmd) {

--- a/wails-app/proc_windows.go
+++ b/wails-app/proc_windows.go
@@ -4,16 +4,36 @@ package main
 
 import (
 	"os/exec"
+	"syscall"
 )
 
-// setChatProcessGroup is a no-op pending the dedicated Windows pass.
-func setChatProcessGroup(cmd *exec.Cmd) {}
+// hideWindow configures cmd so that no visible console window is created on Windows.
+func hideWindow(cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.HideWindow = true
+	cmd.SysProcAttr.CreationFlags |= 0x08000000 // CREATE_NO_WINDOW
+}
+
+// setChatProcessGroup configures the chat subprocess to run without showing a console window on Windows.
+func setChatProcessGroup(cmd *exec.Cmd) {
+	hideWindow(cmd)
+}
 
 // killChatProcessGroup kills the direct child only on Windows.
 func killChatProcessGroup(cmd *exec.Cmd) {
 	if cmd.Process != nil {
 		_ = cmd.Process.Kill()
 	}
+}
+
+// readProcessCommandLine is a stub on Windows where /proc and ps are unavailable.
+func readProcessCommandLine(pid int) (cmdline string, alive bool, err error) {
+	return "", false, nil
 }
 
 // signalWorkflowPID is a no-op on Windows: POSIX signals are not supported


### PR DESCRIPTION
## Summary

On Windows, console-subsystem executables (such as `monoagentcli.exe`) executed via Go's `exec.Command` or `exec.CommandContext` from a GUI process (`MonoAgent.exe`) allocate and display a visible console window unless `CREATE_NO_WINDOW` (`0x08000000`) or `HideWindow: true` is configured in `SysProcAttr`.

Because periodic polling in the frontend (such as `OrgsPanel.jsx` polling `questions`, `gates`, and `approvals` every 6 seconds) frequently executes `monoagentcli.exe`, this caused Command Prompt windows to repeatedly pop open and flash on screen every few seconds.

This PR:
1. Implements `hideWindow(cmd *exec.Cmd)` in `wails-app/proc_windows.go` setting `HideWindow: true` and `CreationFlags |= 0x08000000` (and an empty no-op stub in `proc_unix.go`).
2. Applies `hideWindow(cmd)` to `exec.Command` / `exec.CommandContext` invocations throughout `wails-app`.
3. Adds a stub for `readProcessCommandLine` in `wails-app/proc_windows.go` so `wails-app` test compilation succeeds on Windows.

Closes #61

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation only
- [ ] Breaking change (fix or feature that changes existing behavior — call out the migration path below)

## Checklist

- [x] `go build ./...` passes
- [x] `go test ./...` passes in `wails-app`
- [x] `gofmt -l .` is clean
