### PR TITLE
fix(secrets): route first-use KEK creation through the file-keyring fallback

### DIFF
--- a/internal/secrets/filekeyring_test.go
+++ b/internal/secrets/filekeyring_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/zalando/go-keyring"
 )
 
 // forceKeyringUnavailable stubs the keyringGet/keyringSet hooks so every OS
@@ -52,6 +54,91 @@ func stubFilePassphrase(t *testing.T, passphrase string) {
 
 func warnCount(buf *bytes.Buffer) int {
 	return strings.Count(buf.String(), "WARN:")
+}
+
+// forceKeyringFirstUseWriteFails stubs keyringGet/keyringSet to reproduce a
+// host where the OS keychain exists (so a read for a not-yet-created KEK
+// correctly reports keyring.ErrNotFound, not a generic "unavailable" error)
+// but writing a new entry fails — the signature of a headless/CI/sandboxed
+// session with no interactive authorization to approve the keychain write
+// (issue #52/#54: on macOS this is a "Keychain Not Found" GUI modal, or the
+// write hanging indefinitely rather than failing fast). Distinct from
+// forceKeyringUnavailable above, which fails the read too and exercises a
+// different fetchOrCreateKEK branch entirely.
+func forceKeyringFirstUseWriteFails(t *testing.T) {
+	t.Helper()
+	writeErr := errors.New("keychain write blocked (forced in test): no interactive session")
+	origGet, origSet := keyringGet, keyringSet
+	t.Cleanup(func() { keyringGet, keyringSet = origGet, origSet })
+	keyringGet = func(service, user string) (string, error) {
+		return "", keyring.ErrNotFound
+	}
+	keyringSet = func(service, user, password string) error {
+		return writeErr
+	}
+}
+
+// TestFileKeyringFallback_FirstUseCreationRoutesToFallback exercises the
+// regression in issue #52/#54: fetchOrCreateKEK's first-use creation branch
+// (keyringGet returns ErrNotFound, meaning no entry exists yet) must also
+// respect MONOAGENT_ALLOW_FILE_KEYRING and route to the file-based fallback
+// BEFORE ever attempting a real keychain write — not merely fall back after
+// a write failure, since a blocked interactive write can hang indefinitely
+// rather than return an error to fall back from.
+func TestFileKeyringFallback_FirstUseCreationRoutesToFallback(t *testing.T) {
+	resetKEKState(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(fileKeyringEnv, "1")
+	warns := captureFileKeyringWarns(t)
+	forceKeyringFirstUseWriteFails(t)
+	stubFilePassphrase(t, "correct horse battery staple")
+	ctx := context.Background()
+
+	db := newSecretsTestDB(t)
+	id, err := Add(ctx, db.DB, "default", "secret", "first-use-key", map[string]string{"secret": "v1"}, "", "", "")
+	if err != nil {
+		t.Fatalf("Add on first-use KEK creation with MONOAGENT_ALLOW_FILE_KEYRING=1: %v", err)
+	}
+	fields, _, err := DecryptFields(ctx, db.DB, "default", id)
+	if err != nil {
+		t.Fatalf("DecryptFields after first-use fallback creation: %v", err)
+	}
+	if fields["secret"] != "v1" {
+		t.Fatalf("got %q, want v1", fields["secret"])
+	}
+
+	kekPath := filepath.Join(home, ".monoagent", "vault", ".file-keyring-default")
+	if _, err := os.Stat(kekPath); err != nil {
+		t.Fatalf("expected file-based KEK to be created via the fallback, got: %v", err)
+	}
+	if !strings.Contains(warns.String(), "file-based keyring fallback in use") {
+		t.Fatalf("expected the fallback warning on stderr, got %q", warns.String())
+	}
+}
+
+// TestFileKeyringFallback_FirstUseCreationFailsClosedWithoutEnv proves the
+// fix doesn't change default (opt-in not set) behavior: first-use creation
+// must still attempt the real keychain and surface its error unchanged.
+func TestFileKeyringFallback_FirstUseCreationFailsClosedWithoutEnv(t *testing.T) {
+	resetKEKState(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(fileKeyringEnv, "")
+	forceKeyringFirstUseWriteFails(t)
+	ctx := context.Background()
+
+	db := newSecretsTestDB(t)
+	_, err := Add(ctx, db.DB, "default", "secret", "first-use-key", map[string]string{"secret": "v1"}, "", "", "")
+	if err == nil {
+		t.Fatal("expected Add to fail closed without the fallback env on first-use creation, got nil")
+	}
+	if !strings.Contains(err.Error(), "storing KEK in keychain") {
+		t.Fatalf("expected the keychain write error to surface unchanged, got %q", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".monoagent")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected no vault dir/file without the fallback env, got err %v", err)
+	}
 }
 
 // TestFileKeyringFallback_RoundTrip is the core fallback scenario: OS

--- a/internal/secrets/keyring.go
+++ b/internal/secrets/keyring.go
@@ -165,6 +165,21 @@ func fetchOrCreateKEK(profileID string) ([]byte, error) {
 		return nil, fmt.Errorf("secrets: reading KEK from keychain: %w", err)
 	}
 
+	if fileKeyringEnabled() {
+		// Checked BEFORE attempting the real keychain write, not merely
+		// after one fails: on a headless/CI/sandboxed host with no
+		// interactive session, keyringSet below doesn't necessarily return
+		// a fast error the way the "unavailable" branch above assumes — it
+		// can trigger an interactive OS prompt that hangs indefinitely
+		// (macOS "Keychain Not Found") or fails via an authorization
+		// cancellation. Either way, an opt-in fallback that only kicks in
+		// after the write already failed can't help with the hang case, so
+		// first-use creation skips the real keychain entirely when the
+		// fallback is enabled, mirroring the read-error branch's fallback
+		// but without ever attempting the risky write.
+		return fetchOrCreateFileKEK(profileID)
+	}
+
 	kek := make([]byte, 32)
 	if _, err := rand.Read(kek); err != nil {
 		return nil, fmt.Errorf("secrets: generating KEK: %w", err)


### PR DESCRIPTION
## Summary
- `fetchOrCreateKEK`'s creation branch (`keyringGet` returns `ErrNotFound`) called `keyringSet` against the real OS keychain unconditionally, never checking `fileKeyringEnabled()` the way the keychain-unavailable branch just above it does.
- On a headless/CI/sandboxed host with no interactive session, that write can trigger a macOS "Keychain Not Found" GUI modal or hang indefinitely rather than fail fast — making `MONOAGENT_ALLOW_FILE_KEYRING=1` a no-op for any profile's first use, exactly the case it exists to cover.
- Fix checks `fileKeyringEnabled()` *before* attempting the real keychain write (not attempt-then-fallback-on-error), since a hang can't be recovered from after the fact.

Fixes #52, Fixes #54

## Test plan
- [x] New test `TestFileKeyringFallback_FirstUseCreationRoutesToFallback` reproduces the bug (fails on `master`, passes with the fix)
- [x] New test `TestFileKeyringFallback_FirstUseCreationFailsClosedWithoutEnv` proves default (opt-in not set) behavior is unchanged
- [x] Full `internal/secrets` suite green, including `-race`
- [x] `go build ./...`, `go vet ./...` clean
- [x] Cross-checked `internal/httpapi`, `internal/nodes/vault`, `cmd/monoagentcli` (other callers of this path) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHMRQmj4cHe2KrGcBpd3iw