### PR TITLE
fix(cli): fix tablewriter v1 migration regressions

### DIFF
--- a/cmd/monoagentcli/application.go
+++ b/cmd/monoagentcli/application.go
@@ -163,7 +163,7 @@ func newApplicationListCmd(cfg *globalConfig) *cobra.Command {
 				if a.Tender != nil {
 					title = a.Tender.Title
 				}
-				table.Append([]string{a.ID, string(a.Kind), string(a.Status), title, joinTags(a.Tags), a.UpdatedAt})
+				table.Append([]string{a.ID, string(a.Kind), string(a.Status), truncateStr(title, 40), truncateStr(joinTags(a.Tags), 30), a.UpdatedAt})
 			}
 			table.Render()
 			return nil

--- a/cmd/monoagentcli/application_test.go
+++ b/cmd/monoagentcli/application_test.go
@@ -180,6 +180,44 @@ func TestApplicationListTableShowsJobTitle(t *testing.T) {
 	}
 }
 
+// TestApplicationListTableTruncatesLongValues guards against the tablewriter
+// v1 migration regression where `application list`'s TITLE/TAGS columns lost
+// their old wrap-based readability (v0.0.5 wrapped long cells; the v1
+// migration's shared newPlainTable helper hardcodes no-wrap for every
+// caller) without gaining truncation to compensate, unlike sibling commands
+// that already call truncateStr. A long title/tag must render truncated
+// ("...") rather than as one long unbroken line.
+func TestApplicationListTableTruncatesLongValues(t *testing.T) {
+	dbPath := newApplicationCLITestDB(t)
+
+	runCmd := func(jsonOutput bool, args ...string) (string, error) {
+		cfg := &globalConfig{DBPath: dbPath, JSONOutput: jsonOutput}
+		cmd := newApplicationCmd(cfg)
+		cmd.SetArgs(args)
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		err := cmd.Execute()
+		return out.String(), err
+	}
+
+	longTitle := "Senior Distinguished Principal Staff Software Engineer, Platform Infrastructure and Reliability Team"
+	addOut, err := runCmd(true, "add", "--kind", "job", "--title", longTitle, "--company", "Acme", "--url", "https://acme.example/2")
+	if err != nil {
+		t.Fatalf("application add: %v (%s)", err, addOut)
+	}
+
+	listOut, err := runCmd(false, "list")
+	if err != nil {
+		t.Fatalf("application list: %v", err)
+	}
+	if strings.Contains(listOut, longTitle) {
+		t.Fatalf("expected the long title to be truncated in table output, got the full string unbroken: %s", listOut)
+	}
+	if !strings.Contains(listOut, "...") {
+		t.Fatalf("expected a truncation marker in table output, got: %s", listOut)
+	}
+}
+
 func TestApplicationStatusRejectsInvalidTransition(t *testing.T) {
 	dbPath := newApplicationCLITestDB(t)
 	addOut, err := runApplicationCmd(t, dbPath, "add", "--kind", "job", "--title", "Backend Engineer", "--company", "Acme", "--url", "https://acme.example/1")

--- a/cmd/monoagentcli/login.go
+++ b/cmd/monoagentcli/login.go
@@ -13,6 +13,7 @@ import (
 	"github.com/monoes/mono-agent/internal/bot"
 	"github.com/monoes/mono-agent/internal/chromecookies"
 	"github.com/monoes/mono-agent/internal/secrets"
+	"github.com/olekukonko/tablewriter/tw"
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 
@@ -358,7 +359,8 @@ func newLoginStatusCmd(cfg *globalConfig) *cobra.Command {
 				return nil
 			}
 
-			table := newPlainTable(os.Stdout, []string{"ID", "Platform", "Username", "Status", "Expires", "Added"}, nil)
+			table := newPlainTable(cmd.OutOrStdout(), []string{"ID", "Platform", "Username", "Status", "Expires", "Added"},
+				[]tw.Align{tw.AlignRight, tw.AlignLeft, tw.AlignLeft, tw.AlignLeft, tw.AlignLeft, tw.AlignLeft})
 
 			now := time.Now()
 			for _, s := range sessions {

--- a/cmd/monoagentcli/login_test.go
+++ b/cmd/monoagentcli/login_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/monoes/mono-agent/internal/secrets"
 	"github.com/monoes/mono-agent/internal/storage"
@@ -75,5 +78,69 @@ func TestUpsertSessionRow_CreatesThenUpdatesInPlace(t *testing.T) {
 	}
 	if resolved["cookies"] != string(secondCookies) {
 		t.Fatalf("expected updated cookies, got %q", resolved["cookies"])
+	}
+}
+
+// TestLoginStatusTableRightAlignsNumericIDColumn guards against a
+// tablewriter v1 migration regression: v0.0.5 auto-right-aligned any cell
+// whose content was purely numeric (via regex), with no explicit
+// SetColumnAlignment call needed; v1's shared newPlainTable helper has no
+// such content-sniffing default, so a numeric ID column that never
+// explicitly requested alignment silently went from right- to
+// left-aligned. Seeds two sessions with deliberately different ID widths
+// (1 vs 100, inserted directly so the numeric IDs are controlled rather
+// than relying on autoincrement) and asserts the shorter ID is
+// left-padded to align with the wider one, not left-flush against it.
+func TestLoginStatusTableRightAlignsNumericIDColumn(t *testing.T) {
+	dbPath := t.TempDir() + "/login-status-test.db"
+	keyring.MockInit()
+	db, err := storage.NewDatabase(dbPath)
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+	if err := db.ApplyMigrations(); err != nil {
+		t.Fatalf("ApplyMigrations: %v", err)
+	}
+	t.Cleanup(func() { db.DB.Close() })
+	future := time.Now().Add(24 * time.Hour)
+
+	insert := func(id int, username string) {
+		t.Helper()
+		if _, err := db.DB.Exec(
+			`INSERT INTO crawler_sessions (id, username, platform, cookies_json, expiry, when_added, profile_id, vault_ref) VALUES (?, ?, ?, '{}', ?, ?, 'default', '')`,
+			id, username, "instagram", future, time.Now(),
+		); err != nil {
+			t.Fatalf("seeding session id=%d: %v", id, err)
+		}
+	}
+	insert(1, "shortid")
+	insert(100, "longid")
+
+	cfg := &globalConfig{DBPath: dbPath, JSONOutput: false}
+	cmd := newLoginCmd(cfg)
+	cmd.SetArgs([]string{"status"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("login status: %v", err)
+	}
+
+	lines := strings.Split(out.String(), "\n")
+	var line1, line100 string
+	for _, l := range lines {
+		if strings.Contains(l, "shortid") {
+			line1 = l
+		}
+		if strings.Contains(l, "longid") {
+			line100 = l
+		}
+	}
+	if line1 == "" || line100 == "" {
+		t.Fatalf("expected both session rows in output, got:\n%s", out.String())
+	}
+	pos1 := strings.Index(line1, "1")
+	pos100 := strings.Index(line100, "100")
+	if pos1 <= pos100 {
+		t.Fatalf("expected the single-digit ID to start further right than the 3-digit ID (right-alignment), got ID \"1\" at column %d and \"100\" at column %d\nrow1:   %q\nrow100: %q", pos1, pos100, line1, line100)
 	}
 }

--- a/cmd/monoagentcli/profile_documents.go
+++ b/cmd/monoagentcli/profile_documents.go
@@ -110,7 +110,7 @@ func newProfileDocumentsListCmd(cfg *globalConfig) *cobra.Command {
 			}
 			table := newPlainTable(cmd.OutOrStdout(), []string{"ID", "Filename", "Source", "Uploaded"}, nil)
 			for _, d := range docs {
-				table.Append([]string{d.ID, d.Filename, d.Source, d.CreatedAt})
+				table.Append([]string{d.ID, truncateStr(d.Filename, 50), d.Source, d.CreatedAt})
 			}
 			table.Render()
 			return nil

--- a/cmd/monoagentcli/profile_documents_test.go
+++ b/cmd/monoagentcli/profile_documents_test.go
@@ -41,6 +41,20 @@ func runProfileCmd(t *testing.T, dbPath string, args ...string) (string, error) 
 	return out.String(), err
 }
 
+// runProfileCmdText is runProfileCmd's JSONOutput:false counterpart, for
+// exercising the plain-text table rendering path — mirrors how
+// secret_test.go pairs runSecretCmd/runSecretCmdText.
+func runProfileCmdText(t *testing.T, dbPath string, args ...string) (string, error) {
+	t.Helper()
+	cfg := &globalConfig{DBPath: dbPath, JSONOutput: false}
+	cmd := newProfileCmd(cfg)
+	cmd.SetArgs(args)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
 func TestProfileUploadListDeleteDocument(t *testing.T) {
 	setFakeMonomindOnPathCLI(t)
 	dbPath := newProfileDocsCLITestDB(t)
@@ -64,6 +78,38 @@ func TestProfileUploadListDeleteDocument(t *testing.T) {
 	}
 	if !strings.Contains(listOut, "resume.txt") {
 		t.Fatalf("expected filename in list output, got: %s", listOut)
+	}
+}
+
+// TestProfileDocumentsListTableTruncatesLongFilename guards against the
+// tablewriter v1 migration regression where `documents list`'s FILENAME
+// column lost its old wrap-based readability (see the identical concern in
+// application_test.go's TestApplicationListTableTruncatesLongValues) without
+// gaining truncation to compensate.
+func TestProfileDocumentsListTableTruncatesLongFilename(t *testing.T) {
+	setFakeMonomindOnPathCLI(t)
+	dbPath := newProfileDocsCLITestDB(t)
+
+	longName := "quarterly-performance-review-and-career-development-planning-notes-final-v3.txt"
+	docPath := filepath.Join(t.TempDir(), longName)
+	if err := os.WriteFile(docPath, []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	uploadOut, err := runProfileCmd(t, dbPath, "upload-document", docPath)
+	if err != nil {
+		t.Fatalf("upload-document: %v (%s)", err, uploadOut)
+	}
+
+	listOut, err := runProfileCmdText(t, dbPath, "documents", "list")
+	if err != nil {
+		t.Fatalf("documents list: %v", err)
+	}
+	if strings.Contains(listOut, longName) {
+		t.Fatalf("expected the long filename to be truncated in table output, got the full string unbroken: %s", listOut)
+	}
+	if !strings.Contains(listOut, "...") {
+		t.Fatalf("expected a truncation marker in table output, got: %s", listOut)
 	}
 }
 

--- a/cmd/monoagentcli/secret.go
+++ b/cmd/monoagentcli/secret.go
@@ -253,7 +253,7 @@ func newSecretListCmd(cfg *globalConfig) *cobra.Command {
 			}
 			table := newPlainTable(cmd.OutOrStdout(), []string{"ID", "Kind", "Name", "Username", "Fields", "Updated"}, nil)
 			for _, e := range entries {
-				table.Append([]string{e.ID, e.Kind, e.Name, e.Username, fmt.Sprintf("%d", e.FieldCount), e.UpdatedAt})
+				table.Append([]string{e.ID, e.Kind, truncateStr(e.Name, 40), truncateStr(e.Username, 25), fmt.Sprintf("%d", e.FieldCount), e.UpdatedAt})
 			}
 			table.Render()
 			return nil

--- a/cmd/monoagentcli/secret_test.go
+++ b/cmd/monoagentcli/secret_test.go
@@ -98,6 +98,32 @@ func TestSecretAddListGetReveal(t *testing.T) {
 	}
 }
 
+// TestSecretListTableTruncatesLongName guards against the tablewriter v1
+// migration regression where `secret list`'s NAME column lost its old
+// wrap-based readability (see the identical concern in
+// application_test.go's TestApplicationListTableTruncatesLongValues)
+// without gaining truncation to compensate.
+func TestSecretListTableTruncatesLongName(t *testing.T) {
+	dbPath := newSecretCLITestDB(t)
+
+	longName := "production-database-read-replica-connection-string-us-east-1-backup"
+	addOut, err := runSecretCmd(t, dbPath, "add", "--kind", "secret", "--name", longName, "--value", "v-test1")
+	if err != nil {
+		t.Fatalf("secret add: %v (%s)", err, addOut)
+	}
+
+	listOut, err := runSecretCmdText(t, dbPath, "list")
+	if err != nil {
+		t.Fatalf("secret list: %v", err)
+	}
+	if strings.Contains(listOut, longName) {
+		t.Fatalf("expected the long secret name to be truncated in table output, got the full string unbroken: %s", listOut)
+	}
+	if !strings.Contains(listOut, "...") {
+		t.Fatalf("expected a truncation marker in table output, got: %s", listOut)
+	}
+}
+
 // TestSecretAdd_ReadsValueFromStdinWhenFlagOmitted covers the fallback path
 // in newSecretAddCmd that reads the secret value from stdin (via
 // bufio.NewReader(os.Stdin).ReadString('\n') + strings.TrimRight) when

--- a/cmd/monoagentcli/template.go
+++ b/cmd/monoagentcli/template.go
@@ -74,7 +74,8 @@ func newTemplateListCmd(cfg *globalConfig) *cobra.Command {
 				return nil
 			}
 
-			table := newPlainTable(os.Stdout, []string{"ID", "Name", "Subject", "Body", "Created"}, nil)
+			table := newPlainTable(cmd.OutOrStdout(), []string{"ID", "Name", "Subject", "Body", "Created"},
+				[]tw.Align{tw.AlignRight, tw.AlignLeft, tw.AlignLeft, tw.AlignLeft, tw.AlignLeft})
 
 			for _, t := range templates {
 				table.Append([]string{
@@ -86,7 +87,7 @@ func newTemplateListCmd(cfg *globalConfig) *cobra.Command {
 				})
 			}
 			table.Render()
-			fmt.Fprintf(os.Stderr, "\nTotal: %d template(s)\n", len(templates))
+			fmt.Fprintf(cmd.ErrOrStderr(), "\nTotal: %d template(s)\n", len(templates))
 			return nil
 		},
 	}

--- a/cmd/monoagentcli/template_test.go
+++ b/cmd/monoagentcli/template_test.go
@@ -1,0 +1,72 @@
+// cmd/monoagentcli/template_test.go
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/monoes/mono-agent/internal/storage"
+)
+
+// TestTemplateListTableRightAlignsNumericIDColumn guards against the same
+// tablewriter v1 migration regression covered by login_test.go's
+// TestLoginStatusTableRightAlignsNumericIDColumn: v0.0.5 auto-right-aligned
+// any purely-numeric cell with no explicit SetColumnAlignment call; v1's
+// shared newPlainTable helper has no such content-sniffing default, so
+// `template list`'s numeric ID column silently went from right- to
+// left-aligned. Seeds two templates with explicit, deliberately
+// different-width IDs (1 vs 100, via direct SQL rather than the `create`
+// command, which can't control the autoincrement value) and asserts the
+// shorter ID is left-padded to align with the wider one.
+func TestTemplateListTableRightAlignsNumericIDColumn(t *testing.T) {
+	dbPath := newApplicationCLITestDB(t)
+	db, err := storage.NewDatabase(dbPath)
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+	now := time.Now().UTC()
+	insert := func(id int, name string) {
+		t.Helper()
+		if _, err := db.DB.Exec(
+			`INSERT INTO templates (id, name, subject, body, created_at, updated_at) VALUES (?, ?, '', 'body', ?, ?)`,
+			id, name, now, now,
+		); err != nil {
+			t.Fatalf("seeding template id=%d: %v", id, err)
+		}
+	}
+	insert(1, "shortid")
+	insert(100, "longid")
+	if err := db.DB.Close(); err != nil {
+		t.Fatalf("closing seed db: %v", err)
+	}
+
+	cfg := &globalConfig{DBPath: dbPath, JSONOutput: false}
+	cmd := newTemplateCmd(cfg)
+	cmd.SetArgs([]string{"list"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("template list: %v", err)
+	}
+
+	lines := strings.Split(out.String(), "\n")
+	var line1, line100 string
+	for _, l := range lines {
+		if strings.Contains(l, "shortid") {
+			line1 = l
+		}
+		if strings.Contains(l, "longid") {
+			line100 = l
+		}
+	}
+	if line1 == "" || line100 == "" {
+		t.Fatalf("expected both template rows in output, got:\n%s", out.String())
+	}
+	pos1 := strings.Index(line1, "1")
+	pos100 := strings.Index(line100, "100")
+	if pos1 <= pos100 {
+		t.Fatalf("expected the single-digit ID to start further right than the 3-digit ID (right-alignment), got ID \"1\" at column %d and \"100\" at column %d\nrow1:   %q\nrow100: %q", pos1, pos100, line1, line100)
+	}
+}


### PR DESCRIPTION
## Summary

The tablewriter v0.0.5→v1.1.4 migration (94f47b5) already shipped in an earlier session, but its shared `newPlainTable` helper introduced two silent visual regressions relative to the old behavior:

1. **Lost wrap/truncation for long values.** v0.0.5 wrapped long cell content by default; the shared helper hardcodes no-wrap for every caller. 3 call sites (`application list`, `documents list`, `secret list`) never opted into `truncateStr` the way their siblings already do, so long values now render on one unbroken line. Fixed by adding `truncateStr` calls, matching the convention 17/20 other call sites already use — chosen over restoring wrap-on because every table here is borderless, and a wrapped cell in a borderless table is harder to read than a truncated one.
2. **Lost numeric-column right-alignment.** v0.0.5 auto-right-aligned any purely-numeric cell (regex-based); v1 has no equivalent default. 2 call sites (`login status`, `template list`) have a numeric ID column that silently went from right- to left-aligned. Fixed by passing an explicit `perColumnAlign`, the same mechanism already used correctly by the 4 Field/Value-style tables.

Both fixed call sites (`login status`, `template list`) also switched from a hardcoded `os.Stdout` to `cmd.OutOrStdout()`, making their output capturable by tests — previously only 3/20 call sites were testable this way.

Fixes #53

## Test plan
- [x] 5 new tests, each written first and confirmed failing against the un-fixed code, then passing after the fix: `TestApplicationListTableTruncatesLongValues`, `TestProfileDocumentsListTableTruncatesLongFilename`, `TestSecretListTableTruncatesLongName`, `TestLoginStatusTableRightAlignsNumericIDColumn`, `TestTemplateListTableRightAlignsNumericIDColumn`
- [x] Full `cmd/monoagentcli` suite green; full repo `go test ./...` green
- [x] `go build ./...`, `go vet ./...` clean
- [x] Manually verified rendered output against a real built binary (long title truncates cleanly; no visual artifacts)
- [x] Verified the isolated commit builds/tests cleanly on its own (stashed all unrelated in-progress work in the working tree and re-ran the full suite against just this diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHMRQmj4cHe2KrGcBpd3iw