### PR TITLE
feat(docscan): document discovery scanner, exclude AI agent instruction files

### DIFF
--- a/internal/docscan/scan.go
+++ b/internal/docscan/scan.go
@@ -1,0 +1,144 @@
+// Package docscan finds human-readable, non-code documents under a profile
+// folder. Pure filesystem — no DB/vault dependency, mirroring
+// internal/orgdesign's independence from App/DB.
+package docscan
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// AllowedExtensions are the (lowercase, no dot) extensions treated as "a
+// human-readable, non-code document" for discovery and indexing purposes.
+// Deliberately separate from FileViewerModal.jsx's own fileViewerKind map:
+// that one answers "can this be previewed in-app" (and deliberately
+// includes images, HTML, and source code); this one answers "is this a
+// document worth indexing" (and deliberately excludes both). They cannot
+// share a source of truth anyway (Go vs. JS), and shouldn't even if they
+// could.
+var AllowedExtensions = map[string]bool{
+	"md": true, "markdown": true, "txt": true, "rtf": true,
+	"doc": true, "docx": true, "odt": true,
+	"pdf": true,
+	"xls": true, "xlsx": true, "ods": true, "csv": true,
+	"ppt": true, "pptx": true,
+}
+
+// isDotDir reports whether name is a dot-prefixed directory (.monomind,
+// .git, or any other dot-folder) -- never a user document, always internal
+// tool/VCS state or deliberately hidden by convention. This is a superset
+// of the old exact-match ".monomind"-only exclusion; no other caller needs
+// to change.
+func isDotDir(name string) bool {
+	return strings.HasPrefix(name, ".")
+}
+
+// agentInstructionBasenames are conventional AI coding agent
+// instruction/context filenames -- e.g. CLAUDE.md is read by Claude Code,
+// AGENTS.md is the cross-tool standard read by Codex CLI/Cursor/Claude
+// Code's own fallback/Continue.dev/Aider/OpenHands, GEMINI.md by Gemini
+// CLI. These are never dot-prefixed (so the dot-dir walk exclusion above
+// doesn't catch them) and always carry a real extension (in practice
+// always .md, so the extension allowlist doesn't catch them either), yet
+// they're tool/agent configuration, not content a user would want listed
+// as one of their documents. Deliberately NOT exhaustive of every
+// dot-prefixed convention (.cursorrules, .windsurfrules, .clinerules,
+// .github/copilot-instructions.md, .cursor/rules/*, .windsurf/rules/*):
+// those already fail either the dot-dir exclusion or the extension check
+// on their own, so listing them here would be redundant. Matched against
+// the bare basename only (case-insensitive), so a per-subproject copy in
+// a monorepo-style layout (e.g. packages/foo/CLAUDE.md) is excluded too.
+var agentInstructionBasenames = map[string]bool{
+	"claude.md":          true,
+	"agents.md":          true,
+	"agents.override.md": true,
+	"agent.md":           true,
+	"gemini.md":          true,
+	"qwen.md":            true,
+	"warp.md":            true,
+	"conventions.md":     true,
+}
+
+// IsDocumentFile reports whether filename's extension is in
+// AllowedExtensions (case-insensitive, dot-insensitive) AND its basename
+// isn't a conventional AI agent instruction file (see
+// agentInstructionBasenames) -- the latter technically satisfy the
+// extension check (almost always .md) but are tool configuration, not a
+// document worth indexing or showing to the user.
+func IsDocumentFile(filename string) bool {
+	if agentInstructionBasenames[strings.ToLower(filename)] {
+		return false
+	}
+	ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(filename), "."))
+	if ext == "" {
+		return false
+	}
+	return AllowedExtensions[ext]
+}
+
+// FileInfo is one matched file from a scan.
+type FileInfo struct {
+	Path      string // absolute; root + relpath, root used verbatim -- see Scan
+	Filename  string
+	SizeBytes int64
+	ModTime   int64 // UnixNano
+}
+
+// Scan walks root recursively and returns every regular file matching
+// IsDocumentFile, skipping any dot-prefixed directory (.monomind, .git,
+// etc.) other than root itself -- a profile may be pointed at a
+// dot-prefixed folder via root_dir, and only its descendants are excluded.
+// root is used
+// exactly as given -- never resolved via filepath.Abs/EvalSymlinks -- so
+// every FileInfo.Path is root's own string value plus a relative suffix.
+// This must stay true because monomind.IngestDocument's path-traversal
+// guard compares an ingested path's prefix against
+// profiledir.Root(db, profileID) called completely independently at index
+// time; if this scan silently normalized root (e.g. resolving a symlink)
+// while IngestDocument's own fresh call to profiledir.Root did not, a
+// discovered file could fail to index with a misleading "success"-shaped
+// failure and no obvious cause. Callers MUST pass
+// profiledir.Root(db, profileID) unmodified.
+//
+// A missing root (profile folder not yet created) returns (nil, nil), not
+// an error -- mirrors orgdesign/watch.go's os.IsNotExist(err) handling, so
+// a fresh profile never causes an error banner. Symlinked subdirectories
+// are not followed (fs.WalkDir's default), avoiding cyclic-symlink loops.
+func Scan(root string) ([]FileInfo, error) {
+	if _, err := os.Stat(root); os.IsNotExist(err) {
+		return nil, nil
+	}
+
+	var found []FileInfo
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // transient read error on one entry -- skip it, keep walking
+		}
+		if d.IsDir() {
+			if path != root && isDotDir(d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !d.Type().IsRegular() || !IsDocumentFile(d.Name()) {
+			return nil
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			return nil
+		}
+		found = append(found, FileInfo{
+			Path:      path,
+			Filename:  d.Name(),
+			SizeBytes: info.Size(),
+			ModTime:   info.ModTime().UnixNano(),
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return found, nil
+}

--- a/internal/docscan/scan_test.go
+++ b/internal/docscan/scan_test.go
@@ -1,0 +1,246 @@
+package docscan_test
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/monoes/mono-agent/internal/docscan"
+)
+
+func TestIsDocumentFile(t *testing.T) {
+	cases := map[string]bool{
+		"resume.md":      true,
+		"resume.MD":      true,
+		"notes.markdown": true,
+		"report.pdf":     true,
+		"cv.docx":        true,
+		"cv.doc":         true,
+		"letter.odt":     true,
+		"budget.xlsx":    true,
+		"budget.xls":     true,
+		"budget.ods":     true,
+		"data.csv":       true,
+		"slides.pptx":    true,
+		"slides.ppt":     true,
+		"plain.txt":      true,
+		"formatted.rtf":  true,
+		"main.go":        false,
+		"index.js":       false,
+		"style.css":      false,
+		"noextension":    false,
+		"image.png":      false,
+		"archive.zip":    false,
+		".hidden":        false,
+		"config.yaml":    false,
+		// AI coding agent instruction/context files -- conventionally named,
+		// have a real extension (almost always .md), and don't live inside a
+		// dot-prefixed directory, so neither the extension check nor the
+		// dot-dir walk exclusion would otherwise catch them. Not a user
+		// document even though they pass the extension test.
+		"CLAUDE.md":          false,
+		"claude.md":          false, // case-insensitive match
+		"AGENTS.md":          false,
+		"AGENTS.override.md": false,
+		"AGENT.md":           false, // singular variant some tools use
+		"GEMINI.md":          false,
+		"QWEN.md":            false,
+		"WARP.md":            false,
+		"CONVENTIONS.md":     false, // Aider's convention
+		// A file that merely contains one of these words isn't excluded --
+		// only an exact (case-insensitive) basename match.
+		"CLAUDE_NOTES.md": true,
+		"my-agents.md":    true,
+	}
+	for name, want := range cases {
+		if got := docscan.IsDocumentFile(name); got != want {
+			t.Errorf("IsDocumentFile(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestScanFindsDocumentFilesRecursively(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "resume.md"), "hello")
+	mustWrite(t, filepath.Join(root, "notes.txt"), "hello")
+	mustWrite(t, filepath.Join(root, "image.png"), "not a doc")
+	if err := os.MkdirAll(filepath.Join(root, "sub", "deeper"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(root, "sub", "deeper", "report.pdf"), "hello")
+
+	found, err := docscan.Scan(root)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	var names []string
+	for _, f := range found {
+		names = append(names, f.Filename)
+	}
+	sort.Strings(names)
+	want := []string{"notes.txt", "report.pdf", "resume.md"}
+	if len(names) != len(want) {
+		t.Fatalf("Scan found %v, want %v", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("Scan found %v, want %v", names, want)
+		}
+	}
+}
+
+func TestScanExcludesMonomindDir(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".monomind", "graph"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(root, ".monomind", "graph", "notes.md"), "internal state, not a user doc")
+	mustWrite(t, filepath.Join(root, "real.md"), "a real document")
+
+	found, err := docscan.Scan(root)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(found) != 1 || found[0].Filename != "real.md" {
+		t.Fatalf("expected only real.md, got %+v", found)
+	}
+}
+
+func TestScanExcludesAnyDotDir(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, ".git", "notes.md"), "vcs internals, not a user doc")
+	mustWrite(t, filepath.Join(root, ".foo", "notes.md"), "arbitrary dot-dir, not a user doc")
+	mustWrite(t, filepath.Join(root, "real.md"), "a real document")
+
+	found, err := docscan.Scan(root)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(found) != 1 || found[0].Filename != "real.md" {
+		t.Fatalf("expected only real.md, got %+v", found)
+	}
+}
+
+func TestScanExcludesNestedDotDir(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "sub", ".hidden", "deeper", "notes.md"), "nested dot-dir, not a user doc")
+	mustWrite(t, filepath.Join(root, "sub", "real.md"), "a real document")
+
+	found, err := docscan.Scan(root)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(found) != 1 || found[0].Filename != "real.md" {
+		t.Fatalf("expected only real.md, got %+v", found)
+	}
+}
+
+func TestScanDoesNotExcludeDirWithDotNotAtStart(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "my.project", "notes.md"), "dot not at start -- not excluded")
+
+	found, err := docscan.Scan(root)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(found) != 1 || found[0].Filename != "notes.md" {
+		t.Fatalf("expected notes.md to be found (dir name has a dot but doesn't start with one), got %+v", found)
+	}
+}
+
+// TestScanExcludesAgentInstructionFiles proves the exclusion applies through
+// the full Scan path, not just IsDocumentFile in isolation -- both at the
+// profile root and nested inside an ordinary (non-dot) subdirectory, since
+// these conventions apply per-subproject in monorepo-style layouts too.
+func TestScanExcludesAgentInstructionFiles(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "CLAUDE.md"), "agent instructions, not a user doc")
+	mustWrite(t, filepath.Join(root, "AGENTS.md"), "agent instructions, not a user doc")
+	mustWrite(t, filepath.Join(root, "GEMINI.md"), "agent instructions, not a user doc")
+	mustWrite(t, filepath.Join(root, "sub", "CLAUDE.md"), "nested agent instructions, not a user doc")
+	mustWrite(t, filepath.Join(root, "real.md"), "a real document")
+
+	found, err := docscan.Scan(root)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(found) != 1 || found[0].Filename != "real.md" {
+		t.Fatalf("expected only real.md, got %+v", found)
+	}
+}
+
+func TestScanStillWalksDotPrefixedRootItself(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, ".my-notes")
+	mustWrite(t, filepath.Join(root, "real.md"), "a real document")
+
+	found, err := docscan.Scan(root)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(found) != 1 || found[0].Filename != "real.md" {
+		t.Fatalf("expected real.md to be found even though root itself is dot-prefixed, got %+v", found)
+	}
+}
+
+func TestScanMissingRootReturnsNilNotError(t *testing.T) {
+	found, err := docscan.Scan(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err != nil {
+		t.Fatalf("expected nil error for a missing root, got %v", err)
+	}
+	if found != nil {
+		t.Fatalf("expected nil slice for a missing root, got %+v", found)
+	}
+}
+
+func TestScanReturnsAbsolutePathBuiltFromRootVerbatim(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "sub", "resume.md"), "hello")
+
+	found, err := docscan.Scan(root)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(found) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(found))
+	}
+	want := filepath.Join(root, "sub", "resume.md")
+	if found[0].Path != want {
+		t.Fatalf("Path = %q, want %q (root used verbatim, not resolved)", found[0].Path, want)
+	}
+}
+
+func TestScanReportsSizeAndModTime(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "resume.md")
+	mustWrite(t, path, "twelve bytes!")
+
+	found, err := docscan.Scan(root)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(found) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(found))
+	}
+	fi, statErr := os.Stat(path)
+	if statErr != nil {
+		t.Fatal(statErr)
+	}
+	if found[0].SizeBytes != fi.Size() {
+		t.Errorf("SizeBytes = %d, want %d", found[0].SizeBytes, fi.Size())
+	}
+	if found[0].ModTime != fi.ModTime().UnixNano() {
+		t.Errorf("ModTime = %d, want %d", found[0].ModTime, fi.ModTime().UnixNano())
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/docscan/watch.go
+++ b/internal/docscan/watch.go
@@ -1,0 +1,121 @@
+package docscan
+
+import (
+	"sync"
+	"time"
+)
+
+// DefaultPollInterval is longer than orgdesign's 1.5s because this walks a
+// whole, potentially deep profile tree every tick rather than ReadDir'ing
+// one small flat directory -- and because the latency this hides is a
+// human dropping a file in Finder (imperceptible at a few seconds), not an
+// in-app AI/canvas edit loop where sub-second feedback matters.
+const DefaultPollInterval = 5 * time.Second
+
+type fileState struct {
+	modTime int64
+	size    int64
+}
+
+// Watcher polls root recursively and invokes onChange with the FULL
+// current matching-file snapshot whenever that snapshot differs from the
+// previous tick (add/modify/remove of any tracked file) -- never a
+// per-file callback. Unlike orgdesign.Watcher's (modTime,size)-then-sha256
+// two-tier diff, this uses (modTime, size) only: nothing in this app ever
+// rewrites a discovered or uploaded file's bytes after the fact, so there
+// is no self-write to distinguish from a genuine external edit -- the one
+// thing orgdesign needs sha256 for. Hashing potentially large PDFs/DOCX on
+// every tick for that non-existent purpose would be pure waste.
+//
+// Unlike orgdesign's Start (which primes its snapshot silently and only
+// emits for changes after that), this Watcher's first scan DOES emit:
+// nothing else already knows about pre-existing on-disk documents, so the
+// first pass must itself register everything already on disk.
+type Watcher struct {
+	root     string
+	interval time.Duration
+	onChange func([]FileInfo)
+
+	mu      sync.Mutex
+	files   map[string]fileState // keyed by absolute path
+	scanned bool                 // false until the first scan completes -- see scan's doc comment
+
+	stopCh chan struct{}
+	doneCh chan struct{}
+}
+
+// NewWatcher creates a Watcher for root. Call Start to begin polling. An
+// interval <= 0 uses DefaultPollInterval.
+func NewWatcher(root string, interval time.Duration, onChange func([]FileInfo)) *Watcher {
+	if interval <= 0 {
+		interval = DefaultPollInterval
+	}
+	return &Watcher{
+		root:     root,
+		interval: interval,
+		onChange: onChange,
+		files:    make(map[string]fileState),
+		stopCh:   make(chan struct{}),
+		doneCh:   make(chan struct{}),
+	}
+}
+
+// Start scans immediately (emitting if anything is found) and then polls in
+// a background goroutine. Safe to call once; call Stop to end it.
+func (w *Watcher) Start() {
+	w.scan(true)
+	go func() {
+		defer close(w.doneCh)
+		ticker := time.NewTicker(w.interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-w.stopCh:
+				return
+			case <-ticker.C:
+				w.scan(true)
+			}
+		}
+	}()
+}
+
+// Stop ends polling and waits for the background goroutine to exit.
+func (w *Watcher) Stop() {
+	close(w.stopCh)
+	<-w.doneCh
+}
+
+// scan walks root once, diffs against the last known snapshot, and invokes
+// onChange with the full current snapshot if it differs (add, modify, or
+// remove of any tracked file) and emit is true. The very first scan always
+// counts as a change (even an empty root), since no other mechanism
+// already knows what's on disk before this watcher runs for the first
+// time.
+func (w *Watcher) scan(emit bool) {
+	found, err := Scan(w.root)
+	if err != nil {
+		return // transient read error -- try again next tick
+	}
+
+	w.mu.Lock()
+	cur := make(map[string]fileState, len(found))
+	for _, f := range found {
+		cur[f.Path] = fileState{modTime: f.ModTime, size: f.SizeBytes}
+	}
+	changed := !w.scanned || len(cur) != len(w.files)
+	if !changed {
+		for path, state := range cur {
+			if prev, ok := w.files[path]; !ok || prev != state {
+				changed = true
+				break
+			}
+		}
+	}
+	w.files = cur
+	w.scanned = true
+	w.mu.Unlock()
+
+	if changed && emit {
+		w.onChange(found)
+	}
+}

--- a/internal/docscan/watch_test.go
+++ b/internal/docscan/watch_test.go
@@ -1,0 +1,164 @@
+package docscan_test
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/monoes/mono-agent/internal/docscan"
+)
+
+const testInterval = 30 * time.Millisecond
+
+func waitForCall(t *testing.T, calls *int, mu *sync.Mutex, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := *calls
+		mu.Unlock()
+		if n >= want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d onChange call(s)", want)
+}
+
+func TestWatcherEmitsOnFirstScanForPreExistingFiles(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "resume.md"), "hello")
+
+	var mu sync.Mutex
+	var calls int
+	var lastFiles []docscan.FileInfo
+	w := docscan.NewWatcher(root, testInterval, func(files []docscan.FileInfo) {
+		mu.Lock()
+		calls++
+		lastFiles = files
+		mu.Unlock()
+	})
+	w.Start()
+	defer w.Stop()
+
+	waitForCall(t, &calls, &mu, 1)
+	mu.Lock()
+	defer mu.Unlock()
+	if len(lastFiles) != 1 || lastFiles[0].Filename != "resume.md" {
+		t.Fatalf("expected the pre-existing file on the first scan, got %+v", lastFiles)
+	}
+}
+
+func TestWatcherEmitsWhenFileAdded(t *testing.T) {
+	root := t.TempDir()
+
+	var mu sync.Mutex
+	var calls int
+	var lastFiles []docscan.FileInfo
+	w := docscan.NewWatcher(root, testInterval, func(files []docscan.FileInfo) {
+		mu.Lock()
+		calls++
+		lastFiles = files
+		mu.Unlock()
+	})
+	w.Start()
+	defer w.Stop()
+
+	// First scan: empty root, no files.
+	time.Sleep(testInterval * 2)
+
+	mustWrite(t, filepath.Join(root, "new.txt"), "just added")
+	waitForCall(t, &calls, &mu, 1)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		mu.Lock()
+		found := len(lastFiles) == 1 && lastFiles[0].Filename == "new.txt"
+		mu.Unlock()
+		if found {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected new.txt to eventually appear in a snapshot, got %+v", lastFiles)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func TestWatcherEmitsWhenFileRemoved(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "resume.md")
+	mustWrite(t, path, "hello")
+
+	var mu sync.Mutex
+	var calls int
+	var lastFiles []docscan.FileInfo
+	w := docscan.NewWatcher(root, testInterval, func(files []docscan.FileInfo) {
+		mu.Lock()
+		calls++
+		lastFiles = files
+		mu.Unlock()
+	})
+	w.Start()
+	defer w.Stop()
+	waitForCall(t, &calls, &mu, 1) // initial scan sees resume.md
+
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	waitForCall(t, &calls, &mu, 2)
+	mu.Lock()
+	defer mu.Unlock()
+	if len(lastFiles) != 0 {
+		t.Fatalf("expected an empty snapshot after removal, got %+v", lastFiles)
+	}
+}
+
+func TestWatcherDoesNotEmitWhenNothingChanged(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "resume.md"), "hello")
+
+	var mu sync.Mutex
+	var calls int
+	w := docscan.NewWatcher(root, testInterval, func(files []docscan.FileInfo) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+	})
+	w.Start()
+	defer w.Stop()
+	waitForCall(t, &calls, &mu, 1)
+
+	time.Sleep(testInterval * 5)
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 call with no changes after the first scan, got %d", calls)
+	}
+}
+
+func TestWatcherStopEndsPolling(t *testing.T) {
+	root := t.TempDir()
+	var mu sync.Mutex
+	var calls int
+	w := docscan.NewWatcher(root, testInterval, func(files []docscan.FileInfo) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+	})
+	w.Start()
+	waitForCall(t, &calls, &mu, 1)
+	w.Stop()
+
+	mu.Lock()
+	after := calls
+	mu.Unlock()
+	time.Sleep(testInterval * 5)
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != after {
+		t.Fatalf("expected no more calls after Stop, went from %d to %d", after, calls)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `internal/docscan`, the recursive profile-folder scanner backing the Documents feature's discovery/staleness UI:

- `Scan` finds human-readable, non-code files (md, pdf, docx, xlsx, csv, etc.), skipping any dot-prefixed directory (`.monomind`, `.git`, ...) other than the scan root itself.
- `IsDocumentFile` also excludes conventional AI coding agent instruction files — `CLAUDE.md`, `AGENTS.md`/`AGENTS.override.md`, `AGENT.md`, `GEMINI.md`, `QWEN.md`, `WARP.md`, `CONVENTIONS.md` — matched case-insensitively by basename at any depth. These pass the extension check and aren't dot-prefixed, so neither other filter catches them, but they're tool configuration, not user content. Not exhaustive of dot-prefixed conventions (`.cursorrules`, `.windsurfrules`, `.github/copilot-instructions.md`, etc.) — those already fail the dot-dir or extension check on their own.
- `Watcher` polls a root and emits the current file list on change, for the GUI's live Documents view.

## Test plan
- [x] Full package suite green (16 tests): extension matching, dot-dir exclusion (top-level, nested, non-dot-prefixed lookalikes, dot-prefixed root itself), agent-instruction-file exclusion (both `IsDocumentFile` unit cases and a full `Scan` integration test with a nested copy), missing-root handling, path/size/mtime reporting, watcher change detection
- [x] `go build ./...`, `go vet ./...` clean
- [x] Separately, ran the (now-fixed) scan + the existing `ReconcileDiscoveredDocuments` against the real local database to purge already-registered `CLAUDE.md`/`AGENTS.md`/`GEMINI.md` rows from before this fix existed — not part of this PR's code, just a one-time data cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHMRQmj4cHe2KrGcBpd3iw