### PR TITLE
feat(documents): recursive discovery, staleness tracking, markdown viewer, bulk actions

### DIFF
--- a/cmd/monoagentcli/profile_documents.go
+++ b/cmd/monoagentcli/profile_documents.go
@@ -2,14 +2,44 @@
 package main
 
 import (
+	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/monoes/mono-agent/internal/monomind"
 	"github.com/monoes/mono-agent/internal/vault"
 
 	"github.com/spf13/cobra"
 )
+
+// indexDocument runs knowledge_ingest for path and records the outcome via
+// SetDocumentIndexed, stamping a real (mtime, size) staleness baseline on
+// success. Shared by upload-document (index immediately after copying in)
+// and the standalone `documents index` command (on-demand re-index).
+// os.Stat failures are non-fatal here (best-effort baseline) since a
+// missing baseline just means Stale can never trigger for this success --
+// strictly safer than failing the whole ingest over a stat error. Returns
+// setErr separately (rather than swallowing it) so each caller can decide
+// how to surface a record-keeping failure distinctly from an indexing
+// failure.
+func indexDocument(ctx context.Context, db *sql.DB, profileID, id, path string) (indexed bool, indexErrMsg string, setErr error) {
+	indexed = true
+	if ingestErr := monomind.IngestDocument(ctx, db, profileID, path); ingestErr != nil {
+		indexed = false
+		indexErrMsg = ingestErr.Error()
+	}
+	var mtime, size int64
+	if indexed {
+		if fi, statErr := os.Stat(path); statErr == nil {
+			mtime = fi.ModTime().UnixNano()
+			size = fi.Size()
+		}
+	}
+	setErr = vault.SetDocumentIndexed(ctx, db, profileID, id, indexed, indexErrMsg, mtime, size)
+	return indexed, indexErrMsg, setErr
+}
 
 func newProfileUploadDocumentCmd(cfg *globalConfig) *cobra.Command {
 	var source string
@@ -42,14 +72,11 @@ func newProfileUploadDocumentCmd(cfg *globalConfig) *cobra.Command {
 				}
 			}
 
-			indexed := true
-			indexErrMsg := ""
-			if ingestErr := monomind.IngestDocument(cmd.Context(), db.DB, cfg.ProfileID, storedPath); ingestErr != nil {
-				indexed = false
-				indexErrMsg = ingestErr.Error()
-				fmt.Fprintf(cmd.ErrOrStderr(), "warning: document uploaded but indexing failed: %v\n", ingestErr)
+			indexed, indexErrMsg, setErr := indexDocument(cmd.Context(), db.DB, cfg.ProfileID, id, storedPath)
+			if !indexed {
+				fmt.Fprintf(cmd.ErrOrStderr(), "warning: document uploaded but indexing failed: %s\n", indexErrMsg)
 			}
-			if setErr := vault.SetDocumentIndexed(ctx, db.DB, cfg.ProfileID, id, indexed, indexErrMsg); setErr != nil {
+			if setErr != nil {
 				fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not record indexing status: %v\n", setErr)
 			}
 
@@ -80,7 +107,7 @@ func newProfileDocumentsCmd(cfg *globalConfig) *cobra.Command {
 		Use:   "documents",
 		Short: "Manage uploaded profile documents",
 	}
-	cmd.AddCommand(newProfileDocumentsListCmd(cfg), newProfileDocumentsRmCmd(cfg))
+	cmd.AddCommand(newProfileDocumentsListCmd(cfg), newProfileDocumentsRmCmd(cfg), newProfileDocumentsIndexCmd(cfg))
 	return cmd
 }
 
@@ -139,6 +166,66 @@ func newProfileDocumentsRmCmd(cfg *globalConfig) *cobra.Command {
 				return enc.Encode(map[string]string{"id": args[0]})
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "Deleted %q.\n", args[0])
+			return nil
+		},
+	}
+}
+
+// newProfileDocumentsIndexCmd is the on-demand indexing action for a
+// document the GUI/CLI already knows about (whether uploaded or
+// discovered by a filesystem scan) -- the "Index" button for a Not
+// indexed/Stale row. Output shape mirrors upload-document's (a lowercase
+// JSON map, not documents-list's PascalCase struct encoding): behaviorally
+// this is upload-document's sibling (both attempt one ingest and report
+// pass/fail), not list's.
+func newProfileDocumentsIndexCmd(cfg *globalConfig) *cobra.Command {
+	return &cobra.Command{
+		Use:     "index <id>",
+		Short:   "Index (or re-index) a profile document for knowledge search",
+		Args:    cobra.ExactArgs(1),
+		Example: `  monoagentcli profile documents index doc-003`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			db, err := initDB(cfg)
+			if err != nil {
+				return fmt.Errorf("initializing database: %w", err)
+			}
+			defer db.DB.Close()
+
+			docs, err := vault.ListDocuments(cmd.Context(), db.DB, cfg.ProfileID)
+			if err != nil {
+				return fmt.Errorf("looking up document: %w", err)
+			}
+			var path string
+			found := false
+			for _, d := range docs {
+				if d.ID == args[0] {
+					path = d.Path
+					found = true
+				}
+			}
+			if !found {
+				return errNotFound("document %q not found", args[0])
+			}
+
+			indexed, indexErrMsg, setErr := indexDocument(cmd.Context(), db.DB, cfg.ProfileID, args[0], path)
+			if setErr != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not record indexing status: %v\n", setErr)
+			}
+
+			if cfg.JSONOutput {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				out := map[string]interface{}{"id": args[0], "indexed": indexed}
+				if indexErrMsg != "" {
+					out["index_error"] = indexErrMsg
+				}
+				return enc.Encode(out)
+			}
+			if indexed {
+				fmt.Fprintln(cmd.OutOrStdout(), "Indexed for knowledge search.")
+			} else {
+				fmt.Fprintf(cmd.OutOrStdout(), "Not indexed — %s\n", indexErrMsg)
+			}
 			return nil
 		},
 	}

--- a/cmd/monoagentcli/profile_documents_test.go
+++ b/cmd/monoagentcli/profile_documents_test.go
@@ -184,3 +184,126 @@ func TestProfileSearchKnowledge(t *testing.T) {
 		t.Fatalf("expected excerpt text in output, got: %s", out)
 	}
 }
+
+func uploadDocWithoutIndexing(t *testing.T, dbPath, docPath string) string {
+	t.Helper()
+	// Upload with a broken PATH (no monomind) so it lands Not indexed --
+	// the "index <id>" command under test is what performs the real
+	// ingest attempt, not upload-document.
+	t.Setenv("PATH", t.TempDir()) // deliberately empty, no monomind binary
+	uploadOut, err := runProfileCmd(t, dbPath, "upload-document", docPath)
+	if err != nil {
+		t.Fatalf("upload-document: %v (%s)", err, uploadOut)
+	}
+	id := extractJSONStringField(t, uploadOut, "id")
+	if id == "" {
+		t.Fatalf("expected an id in upload-document output, got: %s", uploadOut)
+	}
+	return id
+}
+
+func extractJSONStringField(t *testing.T, jsonOut, field string) string {
+	t.Helper()
+	marker := `"` + field + `": "`
+	i := strings.Index(jsonOut, marker)
+	if i < 0 {
+		return ""
+	}
+	rest := jsonOut[i+len(marker):]
+	j := strings.Index(rest, `"`)
+	if j < 0 {
+		return ""
+	}
+	return rest[:j]
+}
+
+func TestProfileDocumentsIndexSuccess(t *testing.T) {
+	dbPath := newProfileDocsCLITestDB(t)
+	docPath := filepath.Join(t.TempDir(), "resume.txt")
+	if err := os.WriteFile(docPath, []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	id := uploadDocWithoutIndexing(t, dbPath, docPath)
+
+	setFakeMonomindOnPathCLI(t)
+	indexOut, err := runProfileCmd(t, dbPath, "documents", "index", id)
+	if err != nil {
+		t.Fatalf("documents index: %v (%s)", err, indexOut)
+	}
+	if !strings.Contains(indexOut, `"indexed": true`) {
+		t.Fatalf("expected indexed:true, got: %s", indexOut)
+	}
+
+	listOut, err := runProfileCmd(t, dbPath, "documents", "list")
+	if err != nil {
+		t.Fatalf("documents list: %v (%s)", err, listOut)
+	}
+	if !strings.Contains(listOut, `"Indexed": true`) {
+		t.Fatalf("expected Indexed:true in list output, got: %s", listOut)
+	}
+	if !strings.Contains(listOut, `"Stale": false`) {
+		t.Fatalf("expected Stale:false immediately after indexing, got: %s", listOut)
+	}
+}
+
+func TestProfileDocumentsIndexRecordsFailure(t *testing.T) {
+	dbPath := newProfileDocsCLITestDB(t)
+	docPath := filepath.Join(t.TempDir(), "resume.txt")
+	if err := os.WriteFile(docPath, []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	id := uploadDocWithoutIndexing(t, dbPath, docPath)
+
+	setFakeMonomindOnPathCLI(t)
+	t.Setenv("INGEST_FAIL", "1")
+	indexOut, err := runProfileCmd(t, dbPath, "documents", "index", id)
+	if err != nil {
+		t.Fatalf("documents index should still succeed even when indexing fails: %v (%s)", err, indexOut)
+	}
+	if !strings.Contains(indexOut, `"indexed": false`) {
+		t.Fatalf("expected indexed:false, got: %s", indexOut)
+	}
+	if !strings.Contains(indexOut, `"index_error"`) {
+		t.Fatalf("expected index_error, got: %s", indexOut)
+	}
+}
+
+func TestProfileDocumentsIndexUnknownID(t *testing.T) {
+	setFakeMonomindOnPathCLI(t)
+	dbPath := newProfileDocsCLITestDB(t)
+
+	_, err := runProfileCmd(t, dbPath, "documents", "index", "doc-does-not-exist")
+	if err == nil {
+		t.Fatal("expected an error for an unknown document id")
+	}
+}
+
+func TestProfileDocumentsIndexPreservesPriorSuccessOnLaterFailure(t *testing.T) {
+	dbPath := newProfileDocsCLITestDB(t)
+	docPath := filepath.Join(t.TempDir(), "resume.txt")
+	if err := os.WriteFile(docPath, []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	id := uploadDocWithoutIndexing(t, dbPath, docPath)
+
+	setFakeMonomindOnPathCLI(t)
+	if _, err := runProfileCmd(t, dbPath, "documents", "index", id); err != nil {
+		t.Fatalf("first index: %v", err)
+	}
+
+	t.Setenv("INGEST_FAIL", "1")
+	if _, err := runProfileCmd(t, dbPath, "documents", "index", id); err != nil {
+		t.Fatalf("second (failing) index: %v", err)
+	}
+
+	listOut, err := runProfileCmd(t, dbPath, "documents", "list")
+	if err != nil {
+		t.Fatalf("documents list: %v (%s)", err, listOut)
+	}
+	if !strings.Contains(listOut, `"Indexed": true`) {
+		t.Fatalf("expected the prior success to survive a later failed re-index, got: %s", listOut)
+	}
+	if !strings.Contains(listOut, `"IndexError"`) {
+		t.Fatalf("expected the new failure's IndexError to be recorded, got: %s", listOut)
+	}
+}

--- a/data/migrations/038_vault_documents_discovery.sql
+++ b/data/migrations/038_vault_documents_discovery.sql
@@ -1,0 +1,31 @@
+-- Supports documents discovered by a recursive scan of the profile folder
+-- (source='discovered', see vault.RegisterDiscoveredDocument) and
+-- staleness detection: indexed_mtime/indexed_size_bytes capture a
+-- document's (mtime, size) at the moment it was LAST SUCCESSFULLY
+-- indexed via knowledge_ingest, so a later read can derive "unchanged
+-- since index" from "modified since index" via a cheap stat() instead of
+-- re-hashing file content -- the same (modTime, size) signal
+-- internal/orgdesign/watch.go already uses for its own change detection,
+-- chosen over a persisted content hash because documents (PDFs, DOCX) can
+-- be far larger than the small JSON org configs that pattern was designed
+-- for, and because a false-positive mismatch here only ever produces a
+-- user-visible "Stale" badge -- prompting a harmless, idempotent
+-- re-index, not a correctness problem.
+--
+-- Both columns are NULL for every row that predates this migration and
+-- for any row that has never been successfully indexed -- callers MUST
+-- treat a NULL baseline as "cannot be stale" (Stale=false), never compare
+-- it as zero, or every already-indexed document flips to "Stale" the
+-- first time this runs post-upgrade. See vault.computeStale.
+ALTER TABLE vault_documents ADD COLUMN indexed_mtime INTEGER;
+ALTER TABLE vault_documents ADD COLUMN indexed_size_bytes INTEGER;
+
+-- Non-unique: speeds up ReconcileDiscoveredDocuments' per-profile path
+-- lookups. Deliberately NOT a UNIQUE(profile_id, path) constraint --
+-- vault.MoveFiles (internal/vault/vault.go) rewrites `path` for existing
+-- rows during App.MoveProfileFolder, and a uniqueness constraint would add
+-- a new mid-move failure mode to that already-working path. The
+-- idempotency this feature actually needs is already guaranteed
+-- structurally: discovery reconciliation runs from a single watcher
+-- goroutine, so its own check-then-insert has no real concurrent racer.
+CREATE INDEX IF NOT EXISTS idx_vault_documents_profile_path ON vault_documents(profile_id, path);

--- a/internal/vault/documents.go
+++ b/internal/vault/documents.go
@@ -20,6 +20,28 @@ type DocumentEntry struct {
 	CreatedAt     string
 	Indexed       bool
 	IndexError    string
+	Stale         bool // computed at read time, not a DB column -- see computeStale
+}
+
+// computeStale reports whether an indexed document's content has changed
+// on disk since its last successful index. A NULL baseline (either
+// indexedMTime or indexedSizeBytes not .Valid -- a row that predates the
+// indexed_mtime/indexed_size_bytes columns, or one that has never been
+// successfully indexed) always reads as "not stale": there is no baseline
+// to compare against, and treating a NULL as zero would mark every
+// pre-existing indexed document Stale the moment this column is added.
+// Likewise, a path that can no longer be stat'd (e.g. a discovered
+// document whose source file has since vanished) reads as not stale --
+// there's nothing to confirm a mismatch against.
+func computeStale(indexed bool, indexedMTime, indexedSizeBytes sql.NullInt64, path string) bool {
+	if !indexed || !indexedMTime.Valid || !indexedSizeBytes.Valid {
+		return false
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return fi.ModTime().UnixNano() != indexedMTime.Int64 || fi.Size() != indexedSizeBytes.Int64
 }
 
 // RegisterDocument copies src into the profile's vault (under a
@@ -115,7 +137,7 @@ func RegisterDocument(ctx context.Context, db *sql.DB, src, source string, appli
 // ListDocuments returns profileID's uploaded documents, newest first.
 func ListDocuments(ctx context.Context, db *sql.DB, profileID string) ([]DocumentEntry, error) {
 	rows, err := db.QueryContext(ctx,
-		`SELECT id, path, filename, size_bytes, source, COALESCE(application_id, ''), created_at, indexed, COALESCE(index_error, '')
+		`SELECT id, path, filename, size_bytes, source, COALESCE(application_id, ''), created_at, indexed, COALESCE(index_error, ''), indexed_mtime, indexed_size_bytes
 		 FROM vault_documents WHERE profile_id = ? ORDER BY seq DESC`, profileID)
 	if err != nil {
 		return nil, fmt.Errorf("vault.ListDocuments: %w", err)
@@ -124,9 +146,11 @@ func ListDocuments(ctx context.Context, db *sql.DB, profileID string) ([]Documen
 	docs := []DocumentEntry{}
 	for rows.Next() {
 		var d DocumentEntry
-		if err := rows.Scan(&d.ID, &d.Path, &d.Filename, &d.SizeBytes, &d.Source, &d.ApplicationID, &d.CreatedAt, &d.Indexed, &d.IndexError); err != nil {
+		var indexedMTime, indexedSizeBytes sql.NullInt64
+		if err := rows.Scan(&d.ID, &d.Path, &d.Filename, &d.SizeBytes, &d.Source, &d.ApplicationID, &d.CreatedAt, &d.Indexed, &d.IndexError, &indexedMTime, &indexedSizeBytes); err != nil {
 			return nil, fmt.Errorf("vault.ListDocuments: scan: %w", err)
 		}
+		d.Stale = computeStale(d.Indexed, indexedMTime, indexedSizeBytes, d.Path)
 		docs = append(docs, d)
 	}
 	return docs, rows.Err()
@@ -134,15 +158,37 @@ func ListDocuments(ctx context.Context, db *sql.DB, profileID string) ([]Documen
 
 // SetDocumentIndexed records the outcome of a knowledge_ingest attempt for
 // id, scoped to profileID. indexErr should be empty on success.
-func SetDocumentIndexed(ctx context.Context, db *sql.DB, profileID, id string, indexed bool, indexErr string) error {
+//
+// Asymmetric by design: on success (indexed=true), index_error is cleared
+// and indexed_mtime/indexed_size_bytes are stamped with the file's (mtime,
+// size) at the moment of this successful index -- the new staleness
+// baseline. On failure (indexed=false), ONLY index_error is written; the
+// existing indexed flag and staleness baseline are left untouched, and
+// indexedMTime/indexedSizeBytes are ignored. This matters once a document
+// can be re-indexed on demand: a failed re-index of an
+// already-successfully-indexed document must not un-index it or erase the
+// baseline that makes it show "Stale" rather than "Not indexed" -- the OLD
+// content is still live in monomind's knowledge base until a later attempt
+// actually succeeds.
+func SetDocumentIndexed(ctx context.Context, db *sql.DB, profileID, id string, indexed bool, indexErr string, indexedMTime, indexedSizeBytes int64) error {
 	var errVal interface{}
 	if indexErr != "" {
 		errVal = indexErr
 	}
-	res, err := db.ExecContext(ctx,
-		`UPDATE vault_documents SET indexed = ?, index_error = ? WHERE id = ? AND profile_id = ?`,
-		indexed, errVal, id, profileID,
-	)
+
+	var res sql.Result
+	var err error
+	if indexed {
+		res, err = db.ExecContext(ctx,
+			`UPDATE vault_documents SET indexed = ?, index_error = ?, indexed_mtime = ?, indexed_size_bytes = ? WHERE id = ? AND profile_id = ?`,
+			indexed, errVal, indexedMTime, indexedSizeBytes, id, profileID,
+		)
+	} else {
+		res, err = db.ExecContext(ctx,
+			`UPDATE vault_documents SET index_error = ? WHERE id = ? AND profile_id = ?`,
+			errVal, id, profileID,
+		)
+	}
 	if err != nil {
 		return fmt.Errorf("vault.SetDocumentIndexed: %w", err)
 	}
@@ -156,13 +202,19 @@ func SetDocumentIndexed(ctx context.Context, db *sql.DB, profileID, id string, i
 	return nil
 }
 
-// DeleteDocument removes id's vault_documents row and its file, scoped to
-// profileID. Returns an error if the row does not exist.
+// DeleteDocument removes id's vault_documents row, scoped to profileID.
+// Returns an error if the row does not exist. The underlying file is only
+// removed when the document's source is not "discovered": a discovered
+// document's path is the user's ORIGINAL file (never copied into the
+// vault — see RegisterDiscoveredDocument), so deleting the row must never
+// destroy a file this app never took ownership of. Uploaded/generated
+// documents' files, by contrast, are vault copies this app itself created
+// and owns, and are removed as before.
 func DeleteDocument(ctx context.Context, db *sql.DB, profileID, id string) error {
-	var path string
+	var path, source string
 	err := db.QueryRowContext(ctx,
-		`SELECT path FROM vault_documents WHERE id = ? AND profile_id = ?`, id, profileID,
-	).Scan(&path)
+		`SELECT path, source FROM vault_documents WHERE id = ? AND profile_id = ?`, id, profileID,
+	).Scan(&path, &source)
 	if err == sql.ErrNoRows {
 		return fmt.Errorf("vault.DeleteDocument: id %q not found", id)
 	}
@@ -172,8 +224,180 @@ func DeleteDocument(ctx context.Context, db *sql.DB, profileID, id string) error
 	if _, err := db.ExecContext(ctx, `DELETE FROM vault_documents WHERE id = ? AND profile_id = ?`, id, profileID); err != nil {
 		return fmt.Errorf("vault.DeleteDocument: %w", err)
 	}
-	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "warning: document %s deleted from index but its file could not be removed: %v\n", id, err)
+	if source != "discovered" {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "warning: document %s deleted from index but its file could not be removed: %v\n", id, err)
+		}
 	}
 	return nil
+}
+
+// RegisterDiscoveredDocument inserts a vault_documents row for a
+// human-readable document found under the profile's folder that was never
+// uploaded or generated through this app. Unlike RegisterDocument, this
+// does NOT copy path into the vault -- it is recorded as-is: copying a
+// file that may be far from the vault on every scan tick would be
+// surprising and wasteful, and the original file is the source of truth
+// for a discovered document.
+//
+// Idempotent by (profile_id, path): if a row already exists for this
+// path, its id is returned with created=false instead of inserting a
+// duplicate -- e.g. a scan that also walks vault/documents/ must not
+// double-register an uploaded file's own vault copy.
+func RegisterDiscoveredDocument(ctx context.Context, db *sql.DB, profileID, path, filename string, sizeBytes int64) (id string, created bool, err error) {
+	if existingID, ok, lookupErr := documentIDByPath(ctx, db, profileID, path); lookupErr != nil {
+		return "", false, fmt.Errorf("vault.RegisterDiscoveredDocument: %w", lookupErr)
+	} else if ok {
+		return existingID, false, nil
+	}
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return "", false, fmt.Errorf("vault.RegisterDiscoveredDocument: get conn: %w", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return "", false, fmt.Errorf("vault.RegisterDiscoveredDocument: begin tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+		}
+	}()
+
+	// Another goroutine may have registered this exact path while we
+	// waited for the write lock -- re-check inside the transaction before
+	// inserting, since the pre-check above ran without one.
+	var existingID string
+	err = conn.QueryRowContext(ctx, `SELECT id FROM vault_documents WHERE profile_id = ? AND path = ?`, profileID, path).Scan(&existingID)
+	if err == nil {
+		if _, rbErr := conn.ExecContext(ctx, "ROLLBACK"); rbErr == nil {
+			committed = true
+		}
+		return existingID, false, nil
+	}
+	if err != sql.ErrNoRows {
+		return "", false, fmt.Errorf("vault.RegisterDiscoveredDocument: checking existing: %w", err)
+	}
+
+	var seq int
+	if err := conn.QueryRowContext(ctx, `SELECT COALESCE(MAX(seq), 0) + 1 FROM vault_documents`).Scan(&seq); err != nil {
+		return "", false, fmt.Errorf("vault.RegisterDiscoveredDocument: get next seq: %w", err)
+	}
+	id = fmt.Sprintf("doc-%03d", seq)
+
+	_, err = conn.ExecContext(ctx, `
+		INSERT INTO vault_documents (id, seq, path, filename, size_bytes, source, profile_id, created_at)
+		VALUES (?, ?, ?, ?, ?, 'discovered', ?, datetime('now'))`,
+		id, seq, path, filename, sizeBytes, profileID,
+	)
+	if err != nil {
+		return "", false, fmt.Errorf("vault.RegisterDiscoveredDocument: insert: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return "", false, fmt.Errorf("vault.RegisterDiscoveredDocument: commit: %w", err)
+	}
+	committed = true
+	return id, true, nil
+}
+
+func documentIDByPath(ctx context.Context, db *sql.DB, profileID, path string) (id string, ok bool, err error) {
+	err = db.QueryRowContext(ctx, `SELECT id FROM vault_documents WHERE profile_id = ? AND path = ?`, profileID, path).Scan(&id)
+	if err == sql.ErrNoRows {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return id, true, nil
+}
+
+// DiscoveredFile is one file a filesystem scan (internal/docscan) found, as
+// handed to ReconcileDiscoveredDocuments. Deliberately not
+// docscan.FileInfo: vault (DB-owning) must not import docscan (pure
+// filesystem), so the caller does a trivial field-for-field map between
+// the two, keeping both packages mutually independent.
+type DiscoveredFile struct {
+	Path      string
+	Filename  string
+	SizeBytes int64
+}
+
+// ReconcileDiscoveredDocuments registers a row for every file in found not
+// already tracked under profileID by path, refreshes size_bytes for ones
+// that already are, and removes any "discovered"-sourced row whose path no
+// longer appears in found -- a file that was deleted, moved, or is now
+// excluded by docscan.Scan's own rules (e.g. a dot-folder docscan.isDotDir
+// excludes). found must be a full current snapshot (matching
+// docscan.Watcher's own contract), never a partial delta -- a delta would
+// make every path outside it look "vanished" and wrongly purge it.
+//
+// Only rows with source="discovered" are ever candidates for removal: a
+// manually uploaded/registered document (any other source, e.g. "upload")
+// has a different lifecycle -- see DeleteDocument's own source check -- and
+// simply not appearing in a docscan snapshot (it may not even live under
+// the scanned tree) is never grounds to delete it here.
+//
+// Continues past per-file errors, collecting them, so one bad file never
+// blocks the rest of a scan from being reconciled.
+func ReconcileDiscoveredDocuments(ctx context.Context, db *sql.DB, profileID string, found []DiscoveredFile) (added int, removed int, errs []error) {
+	existing := make(map[string]int64, len(found))
+	rows, err := db.QueryContext(ctx, `SELECT path, size_bytes FROM vault_documents WHERE profile_id = ? AND source = 'discovered'`, profileID)
+	if err != nil {
+		return 0, 0, []error{fmt.Errorf("vault.ReconcileDiscoveredDocuments: loading existing: %w", err)}
+	}
+	for rows.Next() {
+		var path string
+		var size int64
+		if scanErr := rows.Scan(&path, &size); scanErr != nil {
+			rows.Close()
+			return 0, 0, []error{fmt.Errorf("vault.ReconcileDiscoveredDocuments: scanning existing: %w", scanErr)}
+		}
+		existing[path] = size
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, 0, []error{fmt.Errorf("vault.ReconcileDiscoveredDocuments: %w", err)}
+	}
+
+	foundPaths := make(map[string]bool, len(found))
+	for _, f := range found {
+		foundPaths[f.Path] = true
+		size, tracked := existing[f.Path]
+		if !tracked {
+			// RegisterDiscoveredDocument's own lookup matches by path
+			// regardless of source, so a path already tracked under a
+			// different source (e.g. "upload") correctly reports
+			// created=false here rather than inserting a duplicate.
+			_, created, regErr := RegisterDiscoveredDocument(ctx, db, profileID, f.Path, f.Filename, f.SizeBytes)
+			if regErr != nil {
+				errs = append(errs, fmt.Errorf("registering %s: %w", f.Path, regErr))
+				continue
+			}
+			if created {
+				added++
+			}
+			continue
+		}
+		if size != f.SizeBytes {
+			if _, updErr := db.ExecContext(ctx, `UPDATE vault_documents SET size_bytes = ? WHERE profile_id = ? AND path = ?`, f.SizeBytes, profileID, f.Path); updErr != nil {
+				errs = append(errs, fmt.Errorf("refreshing size for %s: %w", f.Path, updErr))
+			}
+		}
+	}
+
+	for path := range existing {
+		if foundPaths[path] {
+			continue
+		}
+		if _, delErr := db.ExecContext(ctx, `DELETE FROM vault_documents WHERE profile_id = ? AND path = ? AND source = 'discovered'`, profileID, path); delErr != nil {
+			errs = append(errs, fmt.Errorf("removing vanished %s: %w", path, delErr))
+			continue
+		}
+		removed++
+	}
+
+	return added, removed, errs
 }

--- a/internal/vault/documents_test.go
+++ b/internal/vault/documents_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/monoes/mono-agent/internal/storage"
@@ -146,5 +147,445 @@ func TestRegisterDocumentWithoutApplicationIDStaysEmpty(t *testing.T) {
 	}
 	if len(docs) != 1 || docs[0].ApplicationID != "" {
 		t.Fatalf("expected empty ApplicationID for a call with none supplied, got %+v", docs)
+	}
+}
+
+// TestComputeStaleFalseWhenBaselineIsNull is the regression test for the
+// bug caught during design: a document indexed BEFORE the
+// indexed_mtime/indexed_size_bytes columns existed (or one that predates
+// this migration entirely) has NULL baselines, which must read as "cannot
+// be stale," never as a zero-value mismatch against the real file's
+// (mtime, size). Simulated here by marking a row indexed directly via a
+// raw UPDATE (bypassing SetDocumentIndexed, which always writes real
+// baselines on success) to reproduce exactly a pre-migration row's shape.
+func TestComputeStaleFalseWhenBaselineIsNull(t *testing.T) {
+	db := newTestDB(t)
+	ctx := vault.ContextWithDB(context.Background(), db.DB)
+	id, err := vault.RegisterDocument(ctx, db.DB, writeTestFile(t, "content"), "upload")
+	if err != nil {
+		t.Fatalf("RegisterDocument: %v", err)
+	}
+	if _, err := db.DB.ExecContext(ctx, `UPDATE vault_documents SET indexed = 1 WHERE id = ?`, id); err != nil {
+		t.Fatalf("simulating a pre-migration indexed row: %v", err)
+	}
+
+	docs, err := vault.ListDocuments(ctx, db.DB, "default")
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	if len(docs) != 1 || !docs[0].Indexed {
+		t.Fatalf("expected the row to be Indexed, got %+v", docs)
+	}
+	if docs[0].Stale {
+		t.Fatalf("expected Stale=false for a NULL baseline, got true: %+v", docs[0])
+	}
+}
+
+func TestComputeStaleFalseWhenUnchangedSinceIndex(t *testing.T) {
+	db := newTestDB(t)
+	ctx := vault.ContextWithDB(context.Background(), db.DB)
+	src := writeTestFile(t, "content")
+	id, err := vault.RegisterDocument(ctx, db.DB, src, "upload")
+	if err != nil {
+		t.Fatalf("RegisterDocument: %v", err)
+	}
+	docs, err := vault.ListDocuments(ctx, db.DB, "default")
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	fi, err := os.Stat(docs[0].Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := vault.SetDocumentIndexed(ctx, db.DB, "default", id, true, "", fi.ModTime().UnixNano(), fi.Size()); err != nil {
+		t.Fatalf("SetDocumentIndexed: %v", err)
+	}
+
+	docs, err = vault.ListDocuments(ctx, db.DB, "default")
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	if docs[0].Stale {
+		t.Fatalf("expected Stale=false immediately after a successful index, got true: %+v", docs[0])
+	}
+}
+
+func TestComputeStaleTrueAfterContentChange(t *testing.T) {
+	db := newTestDB(t)
+	ctx := vault.ContextWithDB(context.Background(), db.DB)
+	src := writeTestFile(t, "content")
+	id, err := vault.RegisterDocument(ctx, db.DB, src, "upload")
+	if err != nil {
+		t.Fatalf("RegisterDocument: %v", err)
+	}
+	docs, err := vault.ListDocuments(ctx, db.DB, "default")
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	path := docs[0].Path
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := vault.SetDocumentIndexed(ctx, db.DB, "default", id, true, "", fi.ModTime().UnixNano(), fi.Size()); err != nil {
+		t.Fatalf("SetDocumentIndexed: %v", err)
+	}
+
+	// Change the file's content/size on disk, after it was indexed.
+	if err := os.WriteFile(path, []byte("much longer content than before"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	docs, err = vault.ListDocuments(ctx, db.DB, "default")
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	if !docs[0].Stale {
+		t.Fatalf("expected Stale=true after the file changed on disk, got false: %+v", docs[0])
+	}
+}
+
+func TestSetDocumentIndexedFailureDoesNotClearPriorSuccessBaseline(t *testing.T) {
+	db := newTestDB(t)
+	ctx := vault.ContextWithDB(context.Background(), db.DB)
+	src := writeTestFile(t, "content")
+	id, err := vault.RegisterDocument(ctx, db.DB, src, "upload")
+	if err != nil {
+		t.Fatalf("RegisterDocument: %v", err)
+	}
+	docs, err := vault.ListDocuments(ctx, db.DB, "default")
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	fi, err := os.Stat(docs[0].Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := vault.SetDocumentIndexed(ctx, db.DB, "default", id, true, "", fi.ModTime().UnixNano(), fi.Size()); err != nil {
+		t.Fatalf("SetDocumentIndexed (success): %v", err)
+	}
+
+	// A later re-index attempt fails.
+	if err := vault.SetDocumentIndexed(ctx, db.DB, "default", id, false, "knowledge_ingest: exit status 1", 0, 0); err != nil {
+		t.Fatalf("SetDocumentIndexed (failure): %v", err)
+	}
+
+	docs, err = vault.ListDocuments(ctx, db.DB, "default")
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	if !docs[0].Indexed {
+		t.Fatalf("expected Indexed to remain true after a failed re-index, got false: %+v", docs[0])
+	}
+	if docs[0].IndexError == "" {
+		t.Fatalf("expected the new IndexError to be recorded, got empty: %+v", docs[0])
+	}
+	if docs[0].Stale {
+		t.Fatalf("expected Stale=false: the prior success's baseline (matching the unchanged file) must survive a failed re-index, got true: %+v", docs[0])
+	}
+}
+
+// TestDeleteDocumentDoesNotRemoveFileForDiscoveredSource is the regression
+// test for the other must-fix bug: a discovered document's path is the
+// user's ORIGINAL file, never a vault copy, so deleting the row must never
+// delete the file.
+func TestDeleteDocumentDoesNotRemoveFileForDiscoveredSource(t *testing.T) {
+	db := newTestDB(t)
+	ctx := vault.ContextWithDB(context.Background(), db.DB)
+	path := writeTestFile(t, "a file the app never copied")
+
+	id, _, err := vault.RegisterDiscoveredDocument(ctx, db.DB, "default", path, filepath.Base(path), 123)
+	if err != nil {
+		t.Fatalf("RegisterDiscoveredDocument: %v", err)
+	}
+
+	if err := vault.DeleteDocument(ctx, db.DB, "default", id); err != nil {
+		t.Fatalf("DeleteDocument: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected the original file to still exist after deleting a discovered row, got: %v", err)
+	}
+	docs, err := vault.ListDocuments(ctx, db.DB, "default")
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	if len(docs) != 0 {
+		t.Fatalf("expected the row to be gone, got %+v", docs)
+	}
+}
+
+func TestDeleteDocumentStillRemovesFileForUploadedSource(t *testing.T) {
+	db := newTestDB(t)
+	ctx := vault.ContextWithDB(context.Background(), db.DB)
+	id, err := vault.RegisterDocument(ctx, db.DB, writeTestFile(t, "content"), "upload")
+	if err != nil {
+		t.Fatalf("RegisterDocument: %v", err)
+	}
+	docs, err := vault.ListDocuments(ctx, db.DB, "default")
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	path := docs[0].Path
+
+	if err := vault.DeleteDocument(ctx, db.DB, "default", id); err != nil {
+		t.Fatalf("DeleteDocument: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected the vault copy to be removed for an uploaded document, stat err: %v", err)
+	}
+}
+
+func TestRegisterDiscoveredDocumentCreatesRowWithoutCopying(t *testing.T) {
+	db := newTestDB(t)
+	ctx := vault.ContextWithDB(context.Background(), db.DB)
+	path := writeTestFile(t, "original content")
+
+	id, created, err := vault.RegisterDiscoveredDocument(ctx, db.DB, "default", path, filepath.Base(path), 17)
+	if err != nil {
+		t.Fatalf("RegisterDiscoveredDocument: %v", err)
+	}
+	if !created {
+		t.Fatalf("expected created=true for a brand new path")
+	}
+
+	docs, err := vault.ListDocuments(ctx, db.DB, "default")
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	if len(docs) != 1 || docs[0].ID != id {
+		t.Fatalf("unexpected documents: %+v", docs)
+	}
+	if docs[0].Path != path {
+		t.Fatalf("expected Path to equal the original path verbatim %q, got %q", path, docs[0].Path)
+	}
+	if docs[0].Source != "discovered" {
+		t.Fatalf("expected source=discovered, got %q", docs[0].Source)
+	}
+
+	// No copy anywhere under the vault's documents/ dir.
+	docsDir := filepath.Join(vault.VaultDir(db.DB, "default"), "documents")
+	entries, _ := os.ReadDir(docsDir)
+	if len(entries) != 0 {
+		t.Fatalf("expected no files copied into the vault for a discovered document, found %d", len(entries))
+	}
+}
+
+func TestRegisterDiscoveredDocumentIdempotentByPath(t *testing.T) {
+	db := newTestDB(t)
+	ctx := vault.ContextWithDB(context.Background(), db.DB)
+	path := writeTestFile(t, "content")
+
+	id1, created1, err := vault.RegisterDiscoveredDocument(ctx, db.DB, "default", path, filepath.Base(path), 7)
+	if err != nil {
+		t.Fatalf("RegisterDiscoveredDocument (1): %v", err)
+	}
+	if !created1 {
+		t.Fatalf("expected created=true the first time")
+	}
+
+	id2, created2, err := vault.RegisterDiscoveredDocument(ctx, db.DB, "default", path, filepath.Base(path), 7)
+	if err != nil {
+		t.Fatalf("RegisterDiscoveredDocument (2): %v", err)
+	}
+	if created2 {
+		t.Fatalf("expected created=false the second time (already tracked)")
+	}
+	if id1 != id2 {
+		t.Fatalf("expected the same id both times, got %q then %q", id1, id2)
+	}
+
+	docs, err := vault.ListDocuments(ctx, db.DB, "default")
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected exactly one row, got %d", len(docs))
+	}
+}
+
+func TestRegisterDiscoveredDocumentPathHasProfileRootPrefix(t *testing.T) {
+	db := newTestDB(t)
+	ctx := vault.ContextWithDB(context.Background(), db.DB)
+	root := vault.VaultDir(db.DB, "default") // under the profile root
+	path := filepath.Join(filepath.Dir(root), "resume.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := vault.RegisterDiscoveredDocument(ctx, db.DB, "default", path, "resume.md", 7)
+	if err != nil {
+		t.Fatalf("RegisterDiscoveredDocument: %v", err)
+	}
+	docs, err := vault.ListDocuments(ctx, db.DB, "default")
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	if !strings.HasPrefix(docs[0].Path, filepath.Dir(root)) {
+		t.Fatalf("expected stored path %q to have the profile root %q as a prefix", docs[0].Path, filepath.Dir(root))
+	}
+}
+
+func TestReconcileDiscoveredDocumentsSkipsAlreadyTrackedPaths(t *testing.T) {
+	db := newTestDB(t)
+	ctx := vault.ContextWithDB(context.Background(), db.DB)
+	id, err := vault.RegisterDocument(ctx, db.DB, writeTestFile(t, "content"), "upload")
+	if err != nil {
+		t.Fatalf("RegisterDocument: %v", err)
+	}
+	docs, err := vault.ListDocuments(ctx, db.DB, "default")
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	uploadedPath := docs[0].Path
+
+	added, removed, errs := vault.ReconcileDiscoveredDocuments(ctx, db.DB, "default", []vault.DiscoveredFile{
+		{Path: uploadedPath, Filename: filepath.Base(uploadedPath), SizeBytes: docs[0].SizeBytes},
+	})
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if added != 0 {
+		t.Fatalf("expected 0 added for an already-tracked path, got %d", added)
+	}
+	if removed != 0 {
+		t.Fatalf("expected 0 removed, got %d", removed)
+	}
+
+	docs, err = vault.ListDocuments(ctx, db.DB, "default")
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	if len(docs) != 1 || docs[0].ID != id {
+		t.Fatalf("expected no duplicate row, got %+v", docs)
+	}
+}
+
+func TestReconcileDiscoveredDocumentsAddsNewFiles(t *testing.T) {
+	db := newTestDB(t)
+	ctx := vault.ContextWithDB(context.Background(), db.DB)
+	path := writeTestFile(t, "brand new")
+
+	added, removed, errs := vault.ReconcileDiscoveredDocuments(ctx, db.DB, "default", []vault.DiscoveredFile{
+		{Path: path, Filename: filepath.Base(path), SizeBytes: 10},
+	})
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if added != 1 {
+		t.Fatalf("expected 1 added, got %d", added)
+	}
+	if removed != 0 {
+		t.Fatalf("expected 0 removed, got %d", removed)
+	}
+
+	docs, err := vault.ListDocuments(ctx, db.DB, "default")
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	if len(docs) != 1 || docs[0].Source != "discovered" {
+		t.Fatalf("unexpected documents: %+v", docs)
+	}
+}
+
+func TestReconcileDiscoveredDocumentsRefreshesSize(t *testing.T) {
+	db := newTestDB(t)
+	ctx := vault.ContextWithDB(context.Background(), db.DB)
+	path := writeTestFile(t, "content")
+
+	if _, _, errs := vault.ReconcileDiscoveredDocuments(ctx, db.DB, "default", []vault.DiscoveredFile{
+		{Path: path, Filename: filepath.Base(path), SizeBytes: 10},
+	}); len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+
+	if _, _, errs := vault.ReconcileDiscoveredDocuments(ctx, db.DB, "default", []vault.DiscoveredFile{
+		{Path: path, Filename: filepath.Base(path), SizeBytes: 99},
+	}); len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+
+	docs, err := vault.ListDocuments(ctx, db.DB, "default")
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	if len(docs) != 1 || docs[0].SizeBytes != 99 {
+		t.Fatalf("expected size_bytes to refresh to 99, got %+v", docs)
+	}
+}
+
+// TestReconcileDiscoveredDocumentsRemovesVanishedDiscoveredFile is the
+// regression test for the gap that let ~1450 stale dot-folder rows survive
+// indefinitely in a real install: a "discovered" row whose path no longer
+// appears in a fresh (full-snapshot) scan -- because the file was deleted,
+// moved, or is now excluded by docscan.Scan's own rules (e.g. a dot-folder
+// docscan.isDotDir now excludes) -- must be purged, not left forever.
+func TestReconcileDiscoveredDocumentsRemovesVanishedDiscoveredFile(t *testing.T) {
+	db := newTestDB(t)
+	ctx := vault.ContextWithDB(context.Background(), db.DB)
+	path := writeTestFile(t, "will vanish")
+
+	if _, _, errs := vault.ReconcileDiscoveredDocuments(ctx, db.DB, "default", []vault.DiscoveredFile{
+		{Path: path, Filename: filepath.Base(path), SizeBytes: 11},
+	}); len(errs) != 0 {
+		t.Fatalf("unexpected errors on initial discovery: %v", errs)
+	}
+	docs, err := vault.ListDocuments(ctx, db.DB, "default")
+	if err != nil || len(docs) != 1 {
+		t.Fatalf("expected 1 discovered doc before reconcile, got %+v (err=%v)", docs, err)
+	}
+
+	// Reconcile again with an empty snapshot -- as docscan.Watcher always
+	// passes the FULL current state, an empty found here means the file
+	// genuinely vanished (or is now excluded), not a partial/delta update.
+	added, removed, errs := vault.ReconcileDiscoveredDocuments(ctx, db.DB, "default", []vault.DiscoveredFile{})
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if added != 0 {
+		t.Fatalf("expected 0 added, got %d", added)
+	}
+	if removed != 1 {
+		t.Fatalf("expected 1 removed, got %d", removed)
+	}
+
+	docs, err = vault.ListDocuments(ctx, db.DB, "default")
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	if len(docs) != 0 {
+		t.Fatalf("expected the vanished discovered doc to be purged, got %+v", docs)
+	}
+}
+
+// TestReconcileDiscoveredDocumentsNeverRemovesNonDiscoveredSource ensures
+// the purge is scoped to source='discovered' only -- a manually
+// uploaded/registered document has a different lifecycle (see
+// DeleteDocument's own source check) and must never be silently deleted
+// just because it doesn't happen to appear in a docscan snapshot.
+func TestReconcileDiscoveredDocumentsNeverRemovesNonDiscoveredSource(t *testing.T) {
+	db := newTestDB(t)
+	ctx := vault.ContextWithDB(context.Background(), db.DB)
+	id, err := vault.RegisterDocument(ctx, db.DB, writeTestFile(t, "uploaded"), "upload")
+	if err != nil {
+		t.Fatalf("RegisterDocument: %v", err)
+	}
+
+	_, removed, errs := vault.ReconcileDiscoveredDocuments(ctx, db.DB, "default", []vault.DiscoveredFile{})
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if removed != 0 {
+		t.Fatalf("expected 0 removed (uploaded doc must survive), got %d", removed)
+	}
+
+	docs, err := vault.ListDocuments(ctx, db.DB, "default")
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	if len(docs) != 1 || docs[0].ID != id {
+		t.Fatalf("expected the uploaded doc to survive reconciliation, got %+v", docs)
 	}
 }

--- a/wails-app/app.go
+++ b/wails-app/app.go
@@ -20,6 +20,7 @@ import (
 	"github.com/monoes/mono-agent/internal/ai"
 	aichat "github.com/monoes/mono-agent/internal/ai/chat"
 	"github.com/monoes/mono-agent/internal/connections"
+	"github.com/monoes/mono-agent/internal/docscan"
 	"github.com/monoes/mono-agent/internal/monomind"
 	"github.com/monoes/mono-agent/internal/orgdesign"
 	"github.com/monoes/mono-agent/internal/profiledir"
@@ -54,6 +55,9 @@ type App struct {
 
 	orgWatchMu sync.Mutex
 	orgWatcher *orgdesign.Watcher // polls the active profile's .monomind/orgs/ dir; see restartOrgWatcher
+
+	docWatchMu sync.Mutex
+	docWatcher *docscan.Watcher // polls the active profile's whole folder (minus .monomind/) for document changes; see restartDocumentWatcher
 }
 
 // cancelHandle wraps a stream's cancel func in a pointer so it has a comparable
@@ -181,6 +185,7 @@ func (a *App) startup(ctx context.Context) {
 	a.migrateProfilesToPerProfileLayout(ctx, db)
 
 	a.restartOrgWatcher()
+	a.restartDocumentWatcher()
 
 	a.emitLog("SYSTEM", "INFO", "Mono Agent UI connected to "+a.dbPath)
 
@@ -281,6 +286,13 @@ func (a *App) shutdown(_ context.Context) {
 		a.orgWatcher = nil
 	}
 	a.orgWatchMu.Unlock()
+
+	a.docWatchMu.Lock()
+	if a.docWatcher != nil {
+		a.docWatcher.Stop()
+		a.docWatcher = nil
+	}
+	a.docWatchMu.Unlock()
 
 	a.runningMu.Lock()
 	for _, cmd := range a.runningCmds {
@@ -1165,6 +1177,7 @@ func (a *App) MoveProfileFolder(profileID, newRootDir string) error {
 	}
 	if profileID == a.getActiveProfileID() {
 		a.restartOrgWatcher()
+		a.restartDocumentWatcher()
 	}
 	a.emitLog("SYSTEM", "INFO", fmt.Sprintf("profile %s: moved to %s", profileID, newRootDir))
 	return nil
@@ -1221,6 +1234,7 @@ func (a *App) SwitchProfile(id string) error {
 	}
 	a.setActiveProfileID(id)
 	a.restartOrgWatcher()
+	a.restartDocumentWatcher()
 	a.emitLog("SYSTEM", "INFO", "Switched to profile: "+id)
 	return nil
 }

--- a/wails-app/app_documents.go
+++ b/wails-app/app_documents.go
@@ -18,6 +18,7 @@ type ProfileDocument struct {
 	CreatedAt     string `json:"created_at"`
 	Indexed       bool   `json:"indexed"`
 	IndexError    string `json:"index_error"`
+	Stale         bool   `json:"stale"`
 }
 
 // KnowledgeSearchResult mirrors internal/monomind.KnowledgeResult (also
@@ -35,6 +36,7 @@ func (a *App) ListProfileDocuments() ([]ProfileDocument, error) {
 		ID, Path, Filename, Source, ApplicationID, CreatedAt, IndexError string
 		SizeBytes                                                        int64
 		Indexed                                                          bool
+		Stale                                                            bool
 	}
 	if err := a.runMonoCLI("", &raw, "profile", "documents", "list"); err != nil {
 		return nil, err
@@ -44,7 +46,7 @@ func (a *App) ListProfileDocuments() ([]ProfileDocument, error) {
 		out = append(out, ProfileDocument{
 			ID: d.ID, Filename: d.Filename, Path: d.Path, SizeBytes: d.SizeBytes,
 			Source: d.Source, ApplicationID: d.ApplicationID, CreatedAt: d.CreatedAt,
-			Indexed: d.Indexed, IndexError: d.IndexError,
+			Indexed: d.Indexed, IndexError: d.IndexError, Stale: d.Stale,
 		})
 	}
 	return out, nil
@@ -77,6 +79,19 @@ func (a *App) UploadProfileDocument(path, source string) (*UploadResult, error) 
 // DeleteProfileDocument removes a document from the vault.
 func (a *App) DeleteProfileDocument(id string) error {
 	return a.runMonoCLI("", nil, "profile", "documents", "rm", id)
+}
+
+// IndexProfileDocument runs (or re-runs) knowledge_ingest for a single
+// already-tracked document -- the on-demand action for a "Not indexed" or
+// "Stale" row; never triggered automatically by discovery. Reuses
+// UploadResult's shape exactly so the frontend can treat a manual index
+// and an upload's own immediate index attempt identically.
+func (a *App) IndexProfileDocument(id string) (*UploadResult, error) {
+	var result UploadResult
+	if err := a.runMonoCLI("", &result, "profile", "documents", "index", id); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // SearchProfileKnowledge searches indexed profile documents (the same

--- a/wails-app/app_documents_watch.go
+++ b/wails-app/app_documents_watch.go
@@ -1,0 +1,57 @@
+// wails-app/app_documents_watch.go
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/monoes/mono-agent/internal/docscan"
+	"github.com/monoes/mono-agent/internal/profiledir"
+	"github.com/monoes/mono-agent/internal/vault"
+	"github.com/wailsapp/wails/v2/pkg/runtime"
+)
+
+// documentRootForActiveProfile resolves the directory the document watcher
+// scans -- the active profile's whole folder. Returns
+// profiledir.Root(a.db, a.getActiveProfileID()) UNMODIFIED (no
+// Abs/EvalSymlinks) -- see internal/docscan.Scan's doc comment for why:
+// monomind.IngestDocument calls profiledir.Root independently at index
+// time and its path-traversal guard requires the two to agree
+// byte-for-byte.
+func (a *App) documentRootForActiveProfile() string {
+	return profiledir.Root(a.db, a.getActiveProfileID())
+}
+
+// restartDocumentWatcher stops any existing document watcher and starts a
+// new one scoped to the active profile's folder. Mirrors restartOrgWatcher
+// exactly in shape and call sites (startup, MoveProfileFolder,
+// SwitchProfile, shutdown).
+func (a *App) restartDocumentWatcher() {
+	a.docWatchMu.Lock()
+	defer a.docWatchMu.Unlock()
+
+	if a.docWatcher != nil {
+		a.docWatcher.Stop()
+		a.docWatcher = nil
+	}
+
+	root := a.documentRootForActiveProfile()
+	if root == "" {
+		return
+	}
+	profileID := a.getActiveProfileID()
+
+	w := docscan.NewWatcher(root, 0, func(files []docscan.FileInfo) {
+		found := make([]vault.DiscoveredFile, len(files))
+		for i, f := range files {
+			found[i] = vault.DiscoveredFile{Path: f.Path, Filename: f.Filename, SizeBytes: f.SizeBytes}
+		}
+		added, removed, errs := vault.ReconcileDiscoveredDocuments(context.Background(), a.db, profileID, found)
+		for _, e := range errs {
+			a.emitLog("SYSTEM", "WARN", fmt.Sprintf("profile %s: document discovery: %v", profileID, e))
+		}
+		runtime.EventsEmit(a.ctx, "documents:changed", map[string]interface{}{"profileID": profileID, "added": added, "removed": removed})
+	})
+	w.Start()
+	a.docWatcher = w
+}

--- a/wails-app/app_files.go
+++ b/wails-app/app_files.go
@@ -25,6 +25,13 @@ func (a *App) documentPath(id string) (string, error) {
 	return path, nil
 }
 
+// maxInlinePreviewBytes caps GetProfileDocumentData's in-memory base64
+// encode. Uploaded documents were always small and user-chosen; discovery
+// (internal/docscan) can now surface anything already sitting in the
+// profile folder, including files far larger than anyone would have
+// picked from a file dialog.
+const maxInlinePreviewBytes = 25 * 1024 * 1024
+
 // GetProfileDocumentData reads a vault document from disk and returns it as
 // a base64 data URL (e.g. "data:application/pdf;base64,..."), the same
 // technique GetVaultImageData uses for images — the reliable way to load
@@ -35,6 +42,9 @@ func (a *App) GetProfileDocumentData(id string) (string, error) {
 	path, err := a.documentPath(id)
 	if err != nil {
 		return "", err
+	}
+	if fi, statErr := os.Stat(path); statErr == nil && fi.Size() > maxInlinePreviewBytes {
+		return "", fmt.Errorf("file too large to preview inline (%d MB) — open it with your system's default application instead", fi.Size()/1024/1024)
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/wails-app/frontend/package-lock.json
+++ b/wails-app/frontend/package-lock.json
@@ -12,7 +12,9 @@
         "lucide-react": "^1.41.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
-        "react-i18next": "^17.0.13"
+        "react-i18next": "^17.0.13",
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^7.0.1",
@@ -676,6 +678,15 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -687,14 +698,45 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -709,6 +751,18 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.4.0.tgz",
+      "integrity": "sha512-1mEZtMKPM09vDmQt5y7YvmN2+DFTP7Tg0EWXdic8/C6VRnpb33e4ghisCIE3WZjsE2N8mf+QV1Zqh7ZFYLWInQ==",
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.1.1",
@@ -823,6 +877,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -833,6 +897,16 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -841,6 +915,56 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/css-tree": {
@@ -868,7 +992,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -900,6 +1023,23 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -907,11 +1047,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -925,6 +1077,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dom-accessibility-api": {
@@ -955,6 +1120,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -974,6 +1161,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1008,6 +1201,46 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -1028,6 +1261,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://locize.com"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/i18next": {
@@ -1066,6 +1309,68 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -1385,6 +1690,16 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "11.5.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
@@ -1425,12 +1740,855 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
@@ -1441,6 +2599,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.18",
@@ -1474,6 +2638,31 @@
       "engines": {
         "node": ">=12.20.0"
       }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "8.0.1",
@@ -1553,6 +2742,16 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1619,6 +2818,33 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -1631,6 +2857,72 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/require-from-string": {
@@ -1713,6 +3005,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -1727,6 +3029,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -1738,6 +3054,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/symbol-tree": {
@@ -1830,6 +3164,26 @@
         "node": ">=20"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/undici": {
       "version": "8.10.2",
       "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.2.tgz",
@@ -1840,6 +3194,93 @@
         "node": ">=22.19.0"
       }
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -1847,6 +3288,34 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -2091,6 +3560,16 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     }
   }
 }

--- a/wails-app/frontend/package.json
+++ b/wails-app/frontend/package.json
@@ -15,7 +15,9 @@
     "lucide-react": "^1.41.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "react-i18next": "^17.0.13"
+    "react-i18next": "^17.0.13",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^7.0.1",

--- a/wails-app/frontend/package.json.md5
+++ b/wails-app/frontend/package.json.md5
@@ -1,1 +1,1 @@
-cf53c8ef7c965fcb67ef2cffd8905e5f
+9dd74cdbadf8df02f27bbdf9c37d68ca

--- a/wails-app/frontend/src/components/FileViewerModal.jsx
+++ b/wails-app/frontend/src/components/FileViewerModal.jsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { X, ExternalLink, AlertTriangle } from 'lucide-react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 import * as WailsApp from '../wailsjs/go/main/App'
 
 const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'svg', 'ico'])
@@ -19,6 +21,55 @@ export function fileViewerKind(filename) {
   if (HTML_EXTS.has(ext)) return 'html'
   if (TEXT_EXTS.has(ext)) return 'text'
   return null
+}
+
+// Pure so it's directly unit-testable without rendering — mirrors
+// fileViewerKind above. Deliberately does NOT change what fileViewerKind
+// itself returns for .md/.markdown (stays 'text', already relied on by
+// existing tests and by the content-fetch dispatch below, which is the
+// same for every non-binary kind) -- this just decides, inside the
+// existing 'text' render branch, whether to run the content through a
+// markdown renderer instead of a bare <pre>.
+export function isMarkdownFile(filename) {
+  const ext = (filename || '').split('.').pop()?.toLowerCase() || ''
+  return ext === 'md' || ext === 'markdown'
+}
+
+// Inline-styled overrides for react-markdown's rendered elements, matching
+// this modal's existing dark theme (#e2e8f0 body text, #00b4d8 accent —
+// see the filename/Open-Externally button above) since everything in this
+// file is inline style={{...}}, no CSS module/global stylesheet to extend
+// instead. remark-gfm (tables/strikethrough/task lists/autolinks) is
+// enabled, but no rehype-raw plugin is added, so raw HTML embedded in a
+// document's markdown source is never rendered -- matching the defensive
+// posture the html viewer below already takes with its empty iframe
+// sandbox, since a "discovered" document's content isn't necessarily
+// authored by the user themselves.
+const mdComponents = {
+  h1: (p) => <h1 style={{ fontSize: 20, margin: '0.6em 0 0.4em', color: '#f1f5f9', borderBottom: '1px solid #1e3a4f', paddingBottom: 6 }} {...p} />,
+  h2: (p) => <h2 style={{ fontSize: 17, margin: '0.6em 0 0.4em', color: '#f1f5f9' }} {...p} />,
+  h3: (p) => <h3 style={{ fontSize: 14, margin: '0.6em 0 0.3em', color: '#f1f5f9' }} {...p} />,
+  p: (p) => <p style={{ margin: '0.5em 0', lineHeight: 1.6 }} {...p} />,
+  a: (p) => <a style={{ color: '#00b4d8' }} target="_blank" rel="noreferrer" {...p} />,
+  ul: (p) => <ul style={{ margin: '0.4em 0', paddingLeft: 22 }} {...p} />,
+  ol: (p) => <ol style={{ margin: '0.4em 0', paddingLeft: 22 }} {...p} />,
+  li: (p) => <li style={{ margin: '0.2em 0' }} {...p} />,
+  blockquote: (p) => <blockquote style={{ margin: '0.5em 0', paddingLeft: 12, borderLeft: '3px solid #1e3a4f', color: '#94a3b8' }} {...p} />,
+  hr: (p) => <hr style={{ border: 'none', borderTop: '1px solid #1e3a4f', margin: '1em 0' }} {...p} />,
+  // react-markdown v9+ dropped the old `inline` prop on `code` (there's no
+  // longer a reliable way to distinguish inline from fenced-block code from
+  // here alone -- see its readme's own syntax-highlighting example, which
+  // only detects a LANGUAGE-TAGGED fence via className, not an untagged
+  // one). Sidestepped rather than worked around: `code`'s background here
+  // matches `pre`'s exactly, so when a block code's <code> ends up nested
+  // inside our styled <pre> below, the two colors don't create a visible
+  // seam -- one unified style that looks right standalone (inline) AND
+  // nested (block), without needing inline/block detection at all.
+  code: (p) => <code style={{ background: '#0d1a26', padding: '1px 5px', borderRadius: 4, fontFamily: 'var(--font-mono)', fontSize: '0.9em' }} {...p} />,
+  pre: (p) => <pre style={{ background: '#0d1a26', border: '1px solid #1e3a4f', borderRadius: 6, padding: 10, overflow: 'auto' }} {...p} />,
+  table: (p) => <table style={{ borderCollapse: 'collapse', margin: '0.5em 0', fontSize: '0.95em' }} {...p} />,
+  th: (p) => <th style={{ border: '1px solid #1e3a4f', padding: '4px 8px', textAlign: 'left', background: '#0d1a26' }} {...p} />,
+  td: (p) => <td style={{ border: '1px solid #1e3a4f', padding: '4px 8px' }} {...p} />,
 }
 
 const fmtBytes = (b) => {
@@ -126,6 +177,13 @@ export default function FileViewerModal({ doc, onClose }) {
               title={doc.filename}
               style={{ width: '100%', height: '70vh', border: 'none', background: '#fff' }}
             />
+          ) : isMarkdownFile(doc.filename) ? (
+            <div style={{
+              width: '100%', maxHeight: '70vh', overflow: 'auto', padding: '14px 18px',
+              fontFamily: 'var(--font-sans, sans-serif)', fontSize: 13, color: '#e2e8f0',
+            }}>
+              <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>{content}</ReactMarkdown>
+            </div>
           ) : (
             <pre style={{
               margin: 0, padding: 14, width: '100%', maxHeight: '70vh',

--- a/wails-app/frontend/src/components/FileViewerModal.render.test.jsx
+++ b/wails-app/frontend/src/components/FileViewerModal.render.test.jsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, waitFor, cleanup } from '@testing-library/react'
+import FileViewerModal from './FileViewerModal.jsx'
+import * as WailsApp from '../wailsjs/go/main/App'
+
+// Regression test for the reported bug: opening a .md document showed raw
+// markdown source (literal '#', '**', etc.) in a monospace <pre> instead of
+// rendered formatting. Confirms actual rendered elements appear, not just
+// that a predicate function returns the right boolean.
+
+vi.mock('../wailsjs/go/main/App', () => ({
+  GetProfileDocumentText: vi.fn(),
+  GetProfileDocumentData: vi.fn(),
+  OpenPathWithOS: vi.fn(),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('FileViewerModal markdown rendering', () => {
+  it('renders .md content as formatted markdown, not raw source', async () => {
+    WailsApp.GetProfileDocumentText.mockResolvedValue('# Hello\n\n**bold** text')
+
+    render(<FileViewerModal doc={{ id: 'doc-1', filename: 'notes.md', size_bytes: 100 }} onClose={() => {}} />)
+
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1, name: 'Hello' })).toBeInTheDocument())
+    expect(screen.getByText('bold').tagName).toBe('STRONG')
+
+    // The raw, unrendered markdown source must not appear anywhere.
+    expect(screen.queryByText(/^# Hello/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/\*\*bold\*\*/)).not.toBeInTheDocument()
+  })
+
+  it('still renders non-markdown text files as raw <pre> content, unchanged', async () => {
+    WailsApp.GetProfileDocumentText.mockResolvedValue('plain text, not markdown: # not a heading')
+
+    render(<FileViewerModal doc={{ id: 'doc-2', filename: 'notes.txt', size_bytes: 100 }} onClose={() => {}} />)
+
+    await waitFor(() => expect(screen.getByText(/plain text, not markdown/)).toBeInTheDocument())
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument()
+  })
+
+  it('renders a GFM table for markdown containing one', async () => {
+    WailsApp.GetProfileDocumentText.mockResolvedValue('| A | B |\n| - | - |\n| 1 | 2 |\n')
+
+    render(<FileViewerModal doc={{ id: 'doc-3', filename: 'table.md', size_bytes: 100 }} onClose={() => {}} />)
+
+    await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument())
+    expect(screen.getByText('A')).toBeInTheDocument()
+  })
+})

--- a/wails-app/frontend/src/components/FileViewerModal.test.js
+++ b/wails-app/frontend/src/components/FileViewerModal.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { fileViewerKind } from './FileViewerModal.jsx'
+import { fileViewerKind, isMarkdownFile } from './FileViewerModal.jsx'
 
 describe('fileViewerKind', () => {
   it('recognizes common image extensions', () => {
@@ -29,5 +29,23 @@ describe('fileViewerKind', () => {
     expect(fileViewerKind('')).toBeNull()
     expect(fileViewerKind(undefined)).toBeNull()
     expect(fileViewerKind('README')).toBeNull()
+  })
+})
+
+describe('isMarkdownFile', () => {
+  it('recognizes .md and .markdown, case-insensitively', () => {
+    expect(isMarkdownFile('notes.md')).toBe(true)
+    expect(isMarkdownFile('NOTES.MD')).toBe(true)
+    expect(isMarkdownFile('readme.markdown')).toBe(true)
+    expect(isMarkdownFile('README.MARKDOWN')).toBe(true)
+  })
+  it('returns false for other text extensions', () => {
+    expect(isMarkdownFile('resume.txt')).toBe(false)
+    expect(isMarkdownFile('data.json')).toBe(false)
+  })
+  it('returns false for missing/extensionless filenames', () => {
+    expect(isMarkdownFile('')).toBe(false)
+    expect(isMarkdownFile(undefined)).toBe(false)
+    expect(isMarkdownFile('README')).toBe(false)
   })
 })

--- a/wails-app/frontend/src/pages/Documents.jsx
+++ b/wails-app/frontend/src/pages/Documents.jsx
@@ -1,9 +1,27 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { Upload, Search, Trash2, Sparkles, CheckCircle2, XCircle, Eye } from 'lucide-react'
+import { Upload, Search, Trash2, Sparkles, CheckCircle2, AlertTriangle, XCircle, Eye, PlayCircle } from 'lucide-react'
 import * as WailsApp from '../wailsjs/go/main/App'
 import { confirm } from '../components/ConfirmDialog.jsx'
-import { api, notify, onMonomindInitEvent } from '../services/api.js'
+import { api, notify, onMonomindInitEvent, onDocumentsChanged } from '../services/api.js'
 import FileViewerModal, { fileViewerKind } from '../components/FileViewerModal.jsx'
+
+// maxInlinePreviewBytes mirrors the backend's own GetProfileDocumentData
+// cap (wails-app/app_files.go) so an oversized file is routed straight to
+// OpenPathWithOS instead of round-tripping to Go just to be rejected.
+const maxInlinePreviewBytes = 25 * 1024 * 1024
+
+// documentBadgeState classifies a document row into exactly one of four
+// Knowledge Graph badge states. The 4th state (monomind_not_set_up) only
+// overrides a NEVER-indexed row: a document that was successfully indexed
+// before keeps showing indexed/stale even if monomind later becomes
+// un-initialized for this profile, since that fact doesn't retroactively
+// change what already happened.
+export function documentBadgeState(doc, monomindNotInitialized) {
+  if (!doc.indexed && monomindNotInitialized) return 'monomind_not_set_up'
+  if (doc.indexed && doc.stale) return 'stale'
+  if (doc.indexed) return 'indexed'
+  return 'not_indexed'
+}
 
 export function formatBytes(n) {
   if (n < 1024) return `${n} B`
@@ -44,6 +62,13 @@ export default function Documents() {
   const [initStatus, setInitStatus] = useState('idle') // idle | running | error
   const initRunningRef = useRef(false)
   const [viewingDoc, setViewingDoc] = useState(null)
+  const [indexingIds, setIndexingIds] = useState(() => new Set())
+  const [selectedIds, setSelectedIds] = useState(() => new Set())
+  // null | 'index' | 'delete' — gates re-entrancy on the bulk buttons (and
+  // the per-row Index button, to avoid a race with an in-flight bulk run)
+  // and drives the running bulk button's live progress label.
+  const [bulkBusy, setBulkBusy] = useState(null)
+  const [bulkProgress, setBulkProgress] = useState({ done: 0, total: 0 })
 
   const load = useCallback(async () => {
     try {
@@ -55,6 +80,12 @@ export default function Documents() {
 
   useEffect(() => { load() }, [load])
   useEffect(() => { api.isMonomindInitialized().then(v => setNotInitialized(!v)) }, [])
+
+  // Live-refresh: the background document watcher (wails-app/app_documents_watch.go)
+  // discovers files added to the profile folder from outside the app (e.g.
+  // dropped in via Finder) and reconciles them into the same list this
+  // page reads — reload whenever it signals a change.
+  useEffect(() => onDocumentsChanged(() => load()), [load])
 
   useEffect(() => onMonomindInitEvent((payload) => {
     if (!initRunningRef.current) return
@@ -91,6 +122,109 @@ export default function Documents() {
     }
   }
 
+  // Returns whether indexing succeeded, so bulk callers (runBulkIndex) can
+  // tally failures for their own summary notify() without duplicating this
+  // function's own per-item notify/spinner/reload handling.
+  const handleIndex = async (id) => {
+    setIndexingIds(s => new Set(s).add(id))
+    try {
+      const result = await WailsApp.IndexProfileDocument(id)
+      if (!result.indexed) {
+        notify('index', isMonomindMissing(result.index_error)
+          ? "Not indexed — monomind isn't installed."
+          : 'Indexing failed: ' + result.index_error)
+      }
+      load()
+      return result.indexed
+    } catch (e) {
+      notify('index', 'Indexing failed: ' + e)
+      return false
+    } finally {
+      setIndexingIds(s => { const n = new Set(s); n.delete(id); return n })
+    }
+  }
+
+  const toggleSelected = (id) => {
+    setSelectedIds(s => {
+      const n = new Set(s)
+      if (n.has(id)) n.delete(id); else n.add(id)
+      return n
+    })
+  }
+
+  const allVisibleSelected = docs.length > 0 && docs.every(d => selectedIds.has(d.id))
+  const toggleSelectAll = () => {
+    setSelectedIds(allVisibleSelected ? new Set() : new Set(docs.map(d => d.id)))
+  }
+
+  // Shared by the always-available "Index all" button and the
+  // selection-scoped "Index selected" action -- both filter to the exact
+  // predicate documentBadgeState/the per-row Index button already use
+  // (!indexed || stale), so neither ever redundantly re-indexes an
+  // already-fresh document. Reuses handleIndex per-item, so bulk runs get
+  // the same live per-row spinner and per-item error toast it already has,
+  // for free.
+  const runBulkIndex = async (candidateDocs) => {
+    const toIndex = candidateDocs.filter(d => !d.indexed || d.stale)
+    if (toIndex.length === 0) {
+      notify('index', 'Nothing to index — already up to date.')
+      return
+    }
+    setBulkBusy('index')
+    setBulkProgress({ done: 0, total: toIndex.length })
+    let failed = 0
+    for (const d of toIndex) {
+      const ok = await handleIndex(d.id)
+      if (!ok) failed++
+      setBulkProgress(p => ({ ...p, done: p.done + 1 }))
+    }
+    notify('index', failed > 0
+      ? `Indexed ${toIndex.length - failed} of ${toIndex.length} document${toIndex.length === 1 ? '' : 's'} (${failed} failed).`
+      : `Indexed ${toIndex.length} document${toIndex.length === 1 ? '' : 's'}.`)
+    setBulkBusy(null)
+  }
+
+  // "discovered" documents aren't owned by the app (see handleDelete's
+  // single-item sibling and the per-row Delete button's own source check)
+  // -- silently skipped here rather than erroring, with the skip count
+  // surfaced in the confirm prompt so it's never a silent no-op.
+  const runBulkDelete = async (candidateDocs) => {
+    const toDelete = candidateDocs.filter(d => d.source !== 'discovered')
+    const skipped = candidateDocs.length - toDelete.length
+    if (toDelete.length === 0) {
+      notify('delete', "Nothing to delete — the selected documents are all auto-discovered and can't be deleted.")
+      return
+    }
+    const label = toDelete.length === 1 ? `"${toDelete[0].filename}"` : `${toDelete.length} documents`
+    const suffix = skipped > 0 ? ` (${skipped} auto-discovered document${skipped === 1 ? '' : 's'} in your selection will be skipped)` : ''
+    const ok = await confirm(
+      `Delete ${label}? This removes ${toDelete.length === 1 ? 'it' : 'them'} from the knowledge index too.${suffix}`,
+      { title: 'Delete Documents', confirmLabel: 'Delete', danger: true },
+    )
+    if (!ok) return
+
+    setBulkBusy('delete')
+    setBulkProgress({ done: 0, total: toDelete.length })
+    let failed = 0
+    const deletedIds = new Set()
+    for (const d of toDelete) {
+      try {
+        await WailsApp.DeleteProfileDocument(d.id)
+        deletedIds.add(d.id)
+      } catch (e) {
+        failed++
+        notify('delete', `Failed to delete "${d.filename}": ${e}`)
+      }
+      setBulkProgress(p => ({ ...p, done: p.done + 1 }))
+    }
+    load()
+    setSelectedIds(s => { const n = new Set(s); deletedIds.forEach(id => n.delete(id)); return n })
+    if (failed === 0) {
+      notify('delete', `Deleted ${toDelete.length} document${toDelete.length === 1 ? '' : 's'}.`)
+    }
+    setBulkBusy(null)
+  }
+
   const handleDelete = async (id, filename) => {
     if (!(await confirm(`Delete "${filename}"? This removes it from the knowledge index too.`, { title: 'Delete Document', confirmLabel: 'Delete', danger: true }))) return
     try {
@@ -105,12 +239,17 @@ export default function Documents() {
   // extension; otherwise tell the user and hand the file to the OS's own
   // default application, the same as double-clicking it in a file manager.
   const handleOpenDocument = (d) => {
-    if (fileViewerKind(d.filename)) {
+    if (fileViewerKind(d.filename) && d.size_bytes <= maxInlinePreviewBytes) {
       setViewingDoc(d)
       return
     }
-    const ext = d.filename.split('.').pop()?.toUpperCase() || 'this'
-    notify('open', `No built-in viewer for ${ext} files — opening "${d.filename}" with your system's default application.`)
+    const reason = d.size_bytes > maxInlinePreviewBytes
+      ? `"${d.filename}" is too large to preview in-app`
+      : (() => {
+          const ext = d.filename.split('.').pop()?.toUpperCase() || 'this'
+          return `No built-in viewer for ${ext} files`
+        })()
+    notify('open', `${reason} — opening "${d.filename}" with your system's default application.`)
     WailsApp.OpenPathWithOS(d.path).catch(e => notify('open', `Could not open "${d.filename}": ${e}`))
   }
 
@@ -133,6 +272,28 @@ export default function Documents() {
       <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
         <h2 style={{ margin: 0, fontSize: 16, color: 'var(--text-primary)' }}>Documents</h2>
         <div style={{ flex: 1 }} />
+        {selectedIds.size > 0 && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>{selectedIds.size} selected</span>
+            <button
+              style={btnStyle}
+              disabled={bulkBusy !== null}
+              onClick={() => runBulkIndex(docs.filter(d => selectedIds.has(d.id)))}
+            >
+              <PlayCircle size={13} /> {bulkBusy === 'index' ? `Indexing… (${bulkProgress.done}/${bulkProgress.total})` : `Index selected (${selectedIds.size})`}
+            </button>
+            <button
+              style={{ ...btnStyle, color: '#ef4444', border: '1px solid rgba(239,68,68,0.3)' }}
+              disabled={bulkBusy !== null}
+              onClick={() => runBulkDelete(docs.filter(d => selectedIds.has(d.id)))}
+            >
+              <Trash2 size={13} /> {bulkBusy === 'delete' ? `Deleting… (${bulkProgress.done}/${bulkProgress.total})` : `Delete selected (${selectedIds.size})`}
+            </button>
+          </div>
+        )}
+        <button style={btnStyle} disabled={bulkBusy !== null} onClick={() => runBulkIndex(docs)}>
+          <PlayCircle size={13} /> {bulkBusy === 'index' ? `Indexing… (${bulkProgress.done}/${bulkProgress.total})` : 'Index all'}
+        </button>
         <button style={btnStyle} onClick={handleUpload}><Upload size={13} /> Upload</button>
       </div>
 
@@ -178,6 +339,15 @@ export default function Documents() {
         <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
           <thead>
             <tr style={{ textAlign: 'left', color: 'var(--text-muted)', fontSize: 10, textTransform: 'uppercase' }}>
+              <th style={{ padding: '6px 8px' }}>
+                <input
+                  type="checkbox"
+                  aria-label="Select all documents"
+                  style={{ accentColor: '#00b4d8', width: 14, height: 14 }}
+                  checked={allVisibleSelected}
+                  onChange={toggleSelectAll}
+                />
+              </th>
               <th style={{ padding: '6px 8px' }}>Filename</th>
               <th style={{ padding: '6px 8px' }}>Source</th>
               <th style={{ padding: '6px 8px' }}>Size</th>
@@ -194,36 +364,81 @@ export default function Documents() {
                 style={{ borderTop: '1px solid rgba(255,255,255,0.05)', cursor: 'pointer' }}
                 title="Double-click to view"
               >
+                <td style={{ padding: '8px' }}>
+                  <input
+                    type="checkbox"
+                    aria-label={`Select ${d.filename}`}
+                    style={{ accentColor: '#00b4d8', width: 14, height: 14 }}
+                    checked={selectedIds.has(d.id)}
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={() => toggleSelected(d.id)}
+                  />
+                </td>
                 <td style={{ padding: '8px' }}>{d.filename}</td>
                 <td style={{ padding: '8px', color: 'var(--text-muted)' }}>{d.source}</td>
                 <td style={{ padding: '8px', color: 'var(--text-muted)' }}>{formatBytes(d.size_bytes)}</td>
                 <td style={{ padding: '8px', color: 'var(--text-muted)' }}>{d.created_at}</td>
                 <td style={{ padding: '8px' }}>
-                  {d.indexed ? (
-                    <span style={{ display: 'flex', alignItems: 'center', gap: 4, color: '#10b981', fontSize: 10 }}>
-                      <CheckCircle2 size={12} /> Indexed
-                    </span>
-                  ) : (
-                    <span
-                      title={d.index_error || 'Not yet indexed'}
-                      style={{ display: 'flex', alignItems: 'center', gap: 4, color: '#64748b', fontSize: 10, cursor: d.index_error ? 'help' : 'default' }}
-                    >
-                      <XCircle size={12} /> {isMonomindMissing(d.index_error) ? 'Monomind not installed' : 'Not indexed'}
-                    </span>
-                  )}
+                  {(() => {
+                    const state = documentBadgeState(d, notInitialized)
+                    if (state === 'indexed') {
+                      return (
+                        <span style={{ display: 'flex', alignItems: 'center', gap: 4, color: '#10b981', fontSize: 10 }}>
+                          <CheckCircle2 size={12} /> Indexed
+                        </span>
+                      )
+                    }
+                    if (state === 'stale') {
+                      return (
+                        <span
+                          title={d.index_error || 'Content changed on disk since last index'}
+                          style={{ display: 'flex', alignItems: 'center', gap: 4, color: '#f59e0b', fontSize: 10, cursor: 'help' }}
+                        >
+                          <AlertTriangle size={12} /> Stale
+                        </span>
+                      )
+                    }
+                    if (state === 'monomind_not_set_up') {
+                      return (
+                        <span style={{ display: 'flex', alignItems: 'center', gap: 4, color: '#f59e0b', fontSize: 10 }}>
+                          <Sparkles size={12} /> Monomind not set up
+                        </span>
+                      )
+                    }
+                    return (
+                      <span
+                        title={d.index_error || 'Not yet indexed'}
+                        style={{ display: 'flex', alignItems: 'center', gap: 4, color: '#64748b', fontSize: 10, cursor: d.index_error ? 'help' : 'default' }}
+                      >
+                        <XCircle size={12} /> {isMonomindMissing(d.index_error) ? 'Monomind not installed' : 'Not indexed'}
+                      </span>
+                    )
+                  })()}
                 </td>
                 <td style={{ padding: '8px', display: 'flex', gap: 6 }}>
                   <button style={{ ...btnStyle, padding: '4px 8px' }} title="View" onClick={(e) => { e.stopPropagation(); handleOpenDocument(d) }}>
                     <Eye size={12} />
                   </button>
-                  <button style={{ ...btnStyle, color: '#ef4444', border: '1px solid rgba(239,68,68,0.3)', padding: '4px 8px' }} onClick={(e) => { e.stopPropagation(); handleDelete(d.id, d.filename) }}>
-                    <Trash2 size={12} />
-                  </button>
+                  {(d.stale || !d.indexed) && (
+                    <button
+                      style={{ ...btnStyle, padding: '4px 8px' }}
+                      title={d.stale ? 'Re-index' : 'Index'}
+                      disabled={indexingIds.has(d.id) || bulkBusy !== null}
+                      onClick={(e) => { e.stopPropagation(); handleIndex(d.id) }}
+                    >
+                      {indexingIds.has(d.id) ? <div className="spinner" style={{ width: 12, height: 12 }} /> : <PlayCircle size={12} />}
+                    </button>
+                  )}
+                  {d.source !== 'discovered' && (
+                    <button style={{ ...btnStyle, color: '#ef4444', border: '1px solid rgba(239,68,68,0.3)', padding: '4px 8px' }} onClick={(e) => { e.stopPropagation(); handleDelete(d.id, d.filename) }}>
+                      <Trash2 size={12} />
+                    </button>
+                  )}
                 </td>
               </tr>
             ))}
             {docs.length === 0 && (
-              <tr><td colSpan={6} style={{ padding: 16, textAlign: 'center', color: 'var(--text-muted)' }}>No documents uploaded.</td></tr>
+              <tr><td colSpan={7} style={{ padding: 16, textAlign: 'center', color: 'var(--text-muted)' }}>No documents uploaded.</td></tr>
             )}
           </tbody>
         </table>

--- a/wails-app/frontend/src/pages/Documents.render.test.jsx
+++ b/wails-app/frontend/src/pages/Documents.render.test.jsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import Documents from './Documents.jsx'
+import * as WailsApp from '../wailsjs/go/main/App'
+
+vi.mock('../components/ConfirmDialog.jsx', () => ({
+  confirm: vi.fn(() => Promise.resolve(true)),
+}))
+
+vi.mock('../wailsjs/go/main/App', () => ({
+  ListProfileDocuments: vi.fn(),
+  IndexProfileDocument: vi.fn(),
+  DeleteProfileDocument: vi.fn(),
+  UploadProfileDocument: vi.fn(),
+  OpenAnyFilePicker: vi.fn(),
+  SearchProfileKnowledge: vi.fn(),
+  IsMonomindInitialized: vi.fn(() => Promise.resolve(true)),
+}))
+
+// indexed & fresh — "Index all"/"Index selected" must skip this one
+const freshDoc = { id: 'doc-1', filename: 'resume.pdf', source: 'upload', size_bytes: 100, created_at: '2026-01-01', indexed: true, stale: false }
+// never indexed — needs indexing
+const notIndexedDoc = { id: 'doc-2', filename: 'notes.md', source: 'upload', size_bytes: 200, created_at: '2026-01-02', indexed: false, stale: false }
+// indexed but stale — needs re-indexing, and NOT deletable (discovered)
+const staleDiscoveredDoc = { id: 'doc-3', filename: 'AGENTS.md', source: 'discovered', size_bytes: 300, created_at: '2026-01-03', indexed: true, stale: true }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  WailsApp.ListProfileDocuments.mockResolvedValue([freshDoc, notIndexedDoc, staleDiscoveredDoc])
+  WailsApp.IndexProfileDocument.mockResolvedValue({ indexed: true })
+  WailsApp.DeleteProfileDocument.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+async function renderLoaded() {
+  render(<Documents />)
+  await waitFor(() => expect(screen.getByText('resume.pdf')).toBeInTheDocument())
+}
+
+describe('Documents multi-select', () => {
+  it('renders a checkbox per row and a header select-all checkbox', async () => {
+    await renderLoaded()
+    const checkboxes = screen.getAllByRole('checkbox')
+    // 1 header + 3 rows
+    expect(checkboxes).toHaveLength(4)
+  })
+
+  it('header checkbox selects and deselects all visible rows', async () => {
+    await renderLoaded()
+    const [header, row1, row2, row3] = screen.getAllByRole('checkbox')
+    fireEvent.click(header)
+    expect(row1.checked).toBe(true)
+    expect(row2.checked).toBe(true)
+    expect(row3.checked).toBe(true)
+    fireEvent.click(header)
+    expect(row1.checked).toBe(false)
+  })
+
+  it('hides "Index selected"/"Delete selected" with no selection, shows them once something is checked', async () => {
+    await renderLoaded()
+    expect(screen.queryByRole('button', { name: /Index selected/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Delete selected/ })).not.toBeInTheDocument()
+
+    const [, row1] = screen.getAllByRole('checkbox')
+    fireEvent.click(row1)
+
+    expect(screen.getByRole('button', { name: /Index selected/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Delete selected/ })).toBeInTheDocument()
+  })
+})
+
+describe('Documents "Index all"', () => {
+  it('indexes only the documents that need it, skipping already-indexed-and-fresh ones', async () => {
+    await renderLoaded()
+
+    fireEvent.click(screen.getByRole('button', { name: /Index all/ }))
+
+    await waitFor(() => expect(WailsApp.IndexProfileDocument).toHaveBeenCalledTimes(2))
+    expect(WailsApp.IndexProfileDocument).toHaveBeenCalledWith('doc-2')
+    expect(WailsApp.IndexProfileDocument).toHaveBeenCalledWith('doc-3')
+    expect(WailsApp.IndexProfileDocument).not.toHaveBeenCalledWith('doc-1')
+  })
+})
+
+describe('Documents "Delete selected"', () => {
+  it('confirms once, then deletes only the non-discovered documents in the selection', async () => {
+    await renderLoaded()
+
+    const [, row1, , row3] = screen.getAllByRole('checkbox')
+    fireEvent.click(row1) // freshDoc, source: upload — deletable
+    fireEvent.click(row3) // staleDiscoveredDoc, source: discovered — NOT deletable
+
+    fireEvent.click(screen.getByRole('button', { name: /Delete selected/ }))
+
+    const { confirm } = await import('../components/ConfirmDialog.jsx')
+    await waitFor(() => expect(confirm).toHaveBeenCalledTimes(1))
+
+    await waitFor(() => expect(WailsApp.DeleteProfileDocument).toHaveBeenCalledTimes(1))
+    expect(WailsApp.DeleteProfileDocument).toHaveBeenCalledWith('doc-1')
+    expect(WailsApp.DeleteProfileDocument).not.toHaveBeenCalledWith('doc-3')
+  })
+})

--- a/wails-app/frontend/src/pages/Documents.test.js
+++ b/wails-app/frontend/src/pages/Documents.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { formatBytes, isMonomindMissing } from './Documents.jsx'
+import { formatBytes, isMonomindMissing, documentBadgeState } from './Documents.jsx'
 
 describe('formatBytes', () => {
   it('formats bytes under 1KB as-is', () => {
@@ -29,5 +29,24 @@ describe('isMonomindMissing', () => {
   it('returns false for empty/undefined', () => {
     expect(isMonomindMissing('')).toBe(false)
     expect(isMonomindMissing(undefined)).toBe(false)
+  })
+})
+
+describe('documentBadgeState', () => {
+  it('returns indexed for an indexed, non-stale doc', () => {
+    expect(documentBadgeState({ indexed: true, stale: false }, false)).toBe('indexed')
+  })
+  it('returns stale for an indexed doc whose content changed', () => {
+    expect(documentBadgeState({ indexed: true, stale: true }, false)).toBe('stale')
+  })
+  it('returns not_indexed for a never-indexed doc when monomind is set up', () => {
+    expect(documentBadgeState({ indexed: false, stale: false }, false)).toBe('not_indexed')
+  })
+  it('returns monomind_not_set_up for a never-indexed doc when monomind is not set up', () => {
+    expect(documentBadgeState({ indexed: false, stale: false }, true)).toBe('monomind_not_set_up')
+  })
+  it('precedence: an already-indexed doc stays indexed/stale even if monomind later becomes uninitialized', () => {
+    expect(documentBadgeState({ indexed: true, stale: false }, true)).toBe('indexed')
+    expect(documentBadgeState({ indexed: true, stale: true }, true)).toBe('stale')
   })
 })

--- a/wails-app/frontend/src/services/api.js
+++ b/wails-app/frontend/src/services/api.js
@@ -254,6 +254,15 @@ export function onMonomindInitEvent(callback) {
   return subscribeEvent('monomind:initProgress', callback)
 }
 
+// onDocumentsChanged fires when the background document watcher discovers
+// or updates files under the active profile's folder. Payload:
+// {profileID, added}. Triggers a reload; the event carries no document
+// data itself (mirrors onOrgDesignUpdated's payload-is-diagnostic-only
+// discipline) -- callers always just re-fetch via listProfileDocuments.
+export function onDocumentsChanged(callback) {
+  return subscribeEvent('documents:changed', callback)
+}
+
 export const PLATFORMS = ['INSTAGRAM', 'LINKEDIN', 'X', 'TIKTOK']
 export const STATES = ['PENDING', 'RUNNING', 'PAUSED', 'COMPLETED', 'FAILED', 'CANCELLED']
 

--- a/wails-app/frontend/src/wailsjs/go/main/App.d.ts
+++ b/wails-app/frontend/src/wailsjs/go/main/App.d.ts
@@ -205,6 +205,8 @@ export function ImportVaultAll(arg1:string,arg2:string):Promise<main.VaultImport
 
 export function ImportWorkflow(arg1:string):Promise<main.WorkflowImportResult>;
 
+export function IndexProfileDocument(arg1:string):Promise<main.UploadResult>;
+
 export function InitializeMonomindProfile():Promise<string>;
 
 export function IsDBConnected():Promise<boolean>;

--- a/wails-app/frontend/src/wailsjs/go/main/App.js
+++ b/wails-app/frontend/src/wailsjs/go/main/App.js
@@ -402,6 +402,10 @@ export function ImportWorkflow(arg1) {
   return window['go']['main']['App']['ImportWorkflow'](arg1);
 }
 
+export function IndexProfileDocument(arg1) {
+  return window['go']['main']['App']['IndexProfileDocument'](arg1);
+}
+
 export function InitializeMonomindProfile() {
   return window['go']['main']['App']['InitializeMonomindProfile']();
 }

--- a/wails-app/frontend/src/wailsjs/go/models.ts
+++ b/wails-app/frontend/src/wailsjs/go/models.ts
@@ -655,6 +655,7 @@ export namespace main {
 	    created_at: string;
 	    indexed: boolean;
 	    index_error: string;
+	    stale: boolean;
 	
 	    static createFrom(source: any = {}) {
 	        return new ProfileDocument(source);
@@ -671,6 +672,7 @@ export namespace main {
 	        this.created_at = source["created_at"];
 	        this.indexed = source["indexed"];
 	        this.index_error = source["index_error"];
+	        this.stale = source["stale"];
 	    }
 	}
 	export class ProfileInfo {


### PR DESCRIPTION
## Summary

The full Documents GUI feature, built incrementally across this session and landing as one coherent, buildable unit (it was never split into separately-shippable increments as it was developed).

**Backend:**
- Migration 038 adds `indexed_mtime`/`indexed_size_bytes` staleness-baseline columns to `vault_documents`.
- `vault.RegisterDiscoveredDocument`/`ReconcileDiscoveredDocuments`: files found by a recursive profile-folder scan (`internal/docscan`, already merged in #65) get registered without being copied into the vault; reconcile purges rows whose path vanished from a fresh scan.
- `vault.computeStale`: cheap `stat()`-based staleness check, not content hashing.
- `profile documents index <id>` CLI command (on-demand re-index) + `App.IndexProfileDocument` Wails method.
- A document-folder watcher (mirrors the existing org-config watcher) drives live discovery in the running GUI.

**Frontend:**
- Indexed/Stale/Not-indexed badges, checkbox multi-select, an always-available "Index all" button, selection-scoped "Index selected"/"Delete selected" (delete correctly skips `discovered`-source documents).
- `.md`/`.markdown` files now render as real formatted markdown (`react-markdown` + `remark-gfm`) instead of raw source in a `<pre>` block — chosen because it renders to React elements directly, no `dangerouslySetInnerHTML`, no raw-HTML passthrough by default.

## Test plan
- [x] Verified as a genuinely self-contained commit: stashed every other in-progress change in the working tree, built + tested against just this diff, then restored the rest — not just "builds on top of everything else."
- [x] Go: `go build ./...` (both modules), `go test ./internal/vault/... ./internal/docscan/... ./cmd/monoagentcli/...` all green
- [x] Frontend: 87/87 tests pass (11 files), including new `Documents.render.test.jsx`/`FileViewerModal.render.test.jsx` — real RTL render tests proving actual DOM output (rendered `<h1>`/`<strong>` from markdown, checkbox interactions, bulk-action filtering), not just pure-function assertions
- [x] `npm run build` (production Vite build) succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHMRQmj4cHe2KrGcBpd3iw