### PR TITLE
fix(orgs): fix Orgs page spinner stuck forever on cold start under StrictMode

### DIFF
--- a/wails-app/frontend/src/components/OrgsPanel.jsx
+++ b/wails-app/frontend/src/components/OrgsPanel.jsx
@@ -212,11 +212,11 @@ export default function OrgsPanel({ embedded = false, isOpen = true, onClose, pa
   useEffect(() => {
     if (!effectiveOpen) return
     const isFirst = firstLoadRef.current
-    firstLoadRef.current = false
     if (!isFirst) {
       loadOrgs(true)
       return
     }
+    firstLoadRef.current = false
     // The very first load of the app's session can race Go's own startup
     // (getActiveProfileID() defaults to "default" until App.startup()
     // finishes resolving the real active profile — Wails doesn't guarantee
@@ -228,11 +228,13 @@ export default function OrgsPanel({ embedded = false, isOpen = true, onClose, pa
     // fixed delay — a cold start with the social build's node-registry
     // scan can take longer than a one-shot timer accounts for.
     let cancelled = false
+    let started = false
     ;(async () => {
       for (let i = 0; i < 30 && !cancelled; i++) { // ~6s ceiling — startup finishing this slow would be a real problem elsewhere too
         if (await api.isReady()) break
         await new Promise(r => setTimeout(r, 200))
       }
+      if (cancelled) return
       // silent:false (the real bug this whole effect was chasing) — the
       // prior version called loadOrgs(isFirst), which for the very first
       // activation passes isFirst=true straight through as the silent
@@ -244,9 +246,28 @@ export default function OrgsPanel({ embedded = false, isOpen = true, onClose, pa
       // (this effect's isFirst=false branch above) finally passes
       // silent=false for the first time and clears it — exactly "first
       // click shows nothing, navigate away and back and it loads".
-      if (!cancelled) loadOrgs(false)
+      started = true
+      loadOrgs(false)
     })()
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+      // React StrictMode (development only) double-invokes every effect on
+      // initial mount: run it, run its cleanup, run it again. firstLoadRef
+      // is a ref, so it survives that cleanup — meaning the FIRST
+      // invocation's `firstLoadRef.current = false` above was still visible
+      // to the SECOND invocation, which then wrongly took the `!isFirst`
+      // silent branch and never called loadOrgs(false) at all. The result:
+      // orgs loads correctly in the background, but the spinner (already
+      // true from useState's initial value) never clears — permanently,
+      // since firstLoadRef had already been consumed. Un-claiming
+      // firstLoadRef here, but ONLY when this invocation's own polling
+      // never actually reached loadOrgs(false) (`started` is still false),
+      // fixes that: the surviving invocation correctly sees isFirst=true
+      // again and runs the real sequence. A genuine completed first load
+      // (started=true) leaves firstLoadRef consumed as before, so later
+      // re-activations still correctly take the fast silent-refresh path.
+      if (!started) firstLoadRef.current = true
+    }
   }, [effectiveOpen, loadOrgs])
 
   // ── Tab data loading ──

--- a/wails-app/frontend/src/components/OrgsPanel.render.test.jsx
+++ b/wails-app/frontend/src/components/OrgsPanel.render.test.jsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, waitFor, cleanup, act } from '@testing-library/react'
+import OrgsPanel from './OrgsPanel.jsx'
+
+vi.mock('../services/api.js', () => ({
+  api: {
+    isReady: vi.fn(() => Promise.resolve(true)),
+    isMonomindInitialized: vi.fn(() => Promise.resolve(true)),
+    listOrgDesigns: vi.fn(() => Promise.resolve({
+      items: [{ name: 'test-org', goal: 'a goal', status: 'active', roleCount: 1 }],
+    })),
+  },
+  onOrgEvent: vi.fn(() => () => {}),
+  onOrgEventsClosed: vi.fn(() => () => {}),
+  onOrgRunStatus: vi.fn(() => () => {}),
+  onOrgDesignUpdated: vi.fn(() => () => {}),
+  notify: vi.fn(),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+// Regression test for the exact bug reported live: opening the Orgs page
+// shows a spinner that never clears, even though the org list actually
+// loaded successfully underneath. Root cause: OrgsPanel's first-activation
+// effect tracks "is this the first load" with a plain ref (firstLoadRef)
+// that it flips to false as soon as the effect body runs -- but the ref
+// persists across React StrictMode's dev-only mount->cleanup->remount
+// double-invoke of every effect on initial mount, while the *cancellation*
+// of the first invocation's in-flight isReady-polling correctly stops it
+// from ever reaching its loadOrgs(false) call. The second (surviving)
+// invocation then sees firstLoadRef.current already false and takes the
+// "silent re-activation" branch (loadOrgs(true)), which populates the org
+// list but deliberately never touches the loadingOrgs state -- so the
+// spinner shown from the initial useState(true) is never cleared, even
+// though `orgs` itself is correctly populated underneath it.
+//
+// This only reproduces under React.StrictMode (development), which is
+// exactly the `wails dev` environment the bug was reported in -- a
+// production build never double-invokes effects and would not show this.
+it('clears the loading spinner and shows the org list after StrictMode double-invokes the first-load effect', async () => {
+  render(
+    <React.StrictMode>
+      <OrgsPanel />
+    </React.StrictMode>,
+  )
+
+  await waitFor(() => {
+    expect(screen.getByText('test-org')).toBeInTheDocument()
+  })
+  expect(screen.queryByText('No orgs found.')).not.toBeInTheDocument()
+})
+
+// Guards the other half of this effect's contract, which the fix above
+// must not regress: a genuine re-activation (navigating away from Orgs and
+// back, without the panel ever unmounting -- this app keeps visited pages
+// mounted and just toggles pageActive) should silently refresh in the
+// background, never flashing the spinner a second time.
+it('does not re-show the spinner on a later re-activation after the first load already completed', async () => {
+  const { rerender } = render(
+    <React.StrictMode>
+      <OrgsPanel pageActive={true} />
+    </React.StrictMode>,
+  )
+  await waitFor(() => {
+    expect(screen.getByText('test-org')).toBeInTheDocument()
+  })
+
+  await act(async () => {
+    rerender(
+      <React.StrictMode>
+        <OrgsPanel pageActive={false} />
+      </React.StrictMode>,
+    )
+  })
+  await act(async () => {
+    rerender(
+      <React.StrictMode>
+        <OrgsPanel pageActive={true} />
+      </React.StrictMode>,
+    )
+  })
+
+  // Still showing the org list immediately, never a spinner flash.
+  expect(screen.getByText('test-org')).toBeInTheDocument()
+})


### PR DESCRIPTION
## Summary

The Orgs page shows a spinner that never clears on first load, even though the org list actually loaded successfully underneath.

**Root cause**: `OrgsPanel`'s first-activation effect tracked "is this the first load" with a plain ref (`firstLoadRef`), flipped to `false` as soon as the effect body ran. That ref survives React StrictMode's dev-only mount→cleanup→remount double-invoke of every effect on initial mount — but the *cancellation* of the first invocation's in-flight `isReady()`-polling correctly stopped it from ever reaching its `loadOrgs(false)` call. The second (surviving) invocation then saw `firstLoadRef.current` already `false` and took the "silent re-activation" branch (`loadOrgs(true)`), which populates the org list correctly but deliberately never touches the loading-spinner state.

This only reproduces under `React.StrictMode` (development) — i.e. exactly `wails dev` — a production build never double-invokes effects and would not show this.

**Fix**: only "consume" `firstLoadRef` when the load sequence this invocation kicked off actually reaches its `loadOrgs(false)` call (tracked via a local `started` flag); if cancelled before that point, the cleanup un-claims `firstLoadRef` so the surviving invocation retries the real sequence. A genuine completed first load still consumes `firstLoadRef` as before, so later re-activations correctly keep using the fast silent-refresh path.

## Test plan
- [x] New test reproduces the exact bug by rendering `<OrgsPanel>` under `<React.StrictMode>` — confirmed failing against the old code (spinner never clears, org name never appears), passing after the fix
- [x] Second new test guards the adjacent behavior the fix must not regress: a later re-activation (navigate away and back without unmounting) still silently refreshes, no repeated spinner flash
- [x] New test run 5x in a row with no flakiness (async/timing-sensitive by nature)
- [x] Full frontend suite: 89/89 passing
- [x] `npm run build` (production) succeeds
- [x] Verified as a self-contained commit (stashed everything else, tested in isolation)
- [x] `go build ./...` unaffected (pure frontend fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHMRQmj4cHe2KrGcBpd3iw