### PR TITLE
fix(org-designer): stop role inspector from discarding in-progress edits

### DIFF
--- a/wails-app/frontend/src/components/orgdesigner/RoleInspector.jsx
+++ b/wails-app/frontend/src/components/orgdesigner/RoleInspector.jsx
@@ -143,7 +143,18 @@ export default function RoleInspector({ node, allNodes, onPatch, onSetReportsTo,
     setFileRead(policy.fileRead || [])
     setWebAllow(policy.webAllow || [])
     setAutoApproveTools(policy.autoApproveTools || [])
-  }, [node])
+    // Deliberately keyed on node?.id, NOT the node object itself: OrgDesigner
+    // rebuilds a fresh node object (new reference, same id) for every role on
+    // every load()/applyLivePatch()/refreshFromServer() round trip -- including
+    // the one triggered by saving a *different* field on this *same* role, or
+    // an unrelated live org-update event. Neither is gated by isInteractingRef
+    // (that guard only covers canvas drag, never these text fields). Keying on
+    // the full object would re-run this reset on every such reference churn,
+    // silently discarding whatever the user is mid-typing into another field.
+    // Keying on id means: reset when the SELECTED ROLE changes, never just
+    // because its object reference did.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [node?.id])
 
   if (!node) {
     return (

--- a/wails-app/frontend/src/components/orgdesigner/RoleInspector.render.test.jsx
+++ b/wails-app/frontend/src/components/orgdesigner/RoleInspector.render.test.jsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import React from 'react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import RoleInspector from './RoleInspector.jsx'
+
+vi.mock('../../services/api.js', () => ({
+  api: { chooseInstructionsFile: vi.fn() },
+}))
+
+afterEach(() => {
+  cleanup()
+})
+
+function makeNode(overrides = {}) {
+  return {
+    id: 'writer',
+    title: 'Staff Writer',
+    type: 'specialist',
+    parentId: 'root',
+    responsibilities: ['Draft articles', 'Incorporate feedback', 'Hand off to reviewer'],
+    icon: '',
+    rest: { adapter_config: { model: 'gpt-4' } },
+    ...overrides,
+  }
+}
+
+// Regression test for the reported bug: "the fields seem like they don't
+// reflect the selected role." Root cause: RoleInspector's field-sync effect
+// keys on the `node` PROP's object identity ([node] dependency), but
+// OrgDesigner.jsx's load()/applyLivePatch()/refreshFromServer() all
+// unconditionally build a brand-new node object (fresh reference) for every
+// role on every server round-trip -- including the round-trip triggered by
+// saving a *different* field on the *same* role, or an unrelated live
+// org-update event -- none of which are gated by the app's own
+// "user is interacting" guard (isInteractingRef only covers canvas drag,
+// never inspector text fields). Result: any not-yet-blurred edit in the
+// panel is silently discarded and replaced by the last-saved server value
+// the moment any such refresh fires while that same role stays selected.
+it('keeps an in-progress (not yet blurred) edit when the same role re-renders with a new object reference', () => {
+  const nodeA = makeNode()
+  const { rerender } = render(
+    <RoleInspector node={nodeA} allNodes={[nodeA]} onPatch={() => {}} />,
+  )
+
+  const modelInput = screen.getByPlaceholderText('claude-sonnet-4-5')
+  fireEvent.change(modelInput, { target: { value: 'claude-opus-5' } })
+  expect(modelInput).toHaveValue('claude-opus-5')
+
+  // Same role, same underlying data, but a fresh object reference -- exactly
+  // what applyLivePatch/refreshFromServer produce for an "unchanged" role.
+  const nodeAAgain = makeNode()
+  rerender(
+    <RoleInspector node={nodeAAgain} allNodes={[nodeAAgain]} onPatch={() => {}} />,
+  )
+
+  expect(modelInput).toHaveValue('claude-opus-5')
+})
+
+// Guards the behavior the fix must not regress: selecting a genuinely
+// different role must still reset the panel to that role's own values.
+it('resets fields when a different role becomes selected', () => {
+  const nodeA = makeNode()
+  const { rerender } = render(
+    <RoleInspector node={nodeA} allNodes={[nodeA]} onPatch={() => {}} />,
+  )
+  const modelInput = screen.getByPlaceholderText('claude-sonnet-4-5')
+  fireEvent.change(modelInput, { target: { value: 'unsaved-edit' } })
+
+  const nodeB = makeNode({ id: 'editor', title: 'Editor', rest: { adapter_config: { model: 'gpt-3.5' } } })
+  rerender(
+    <RoleInspector node={nodeB} allNodes={[nodeB]} onPatch={() => {}} />,
+  )
+
+  expect(screen.getByPlaceholderText('claude-sonnet-4-5')).toHaveValue('gpt-3.5')
+  expect(screen.getByDisplayValue('Editor')).toBeInTheDocument()
+})


### PR DESCRIPTION
## Summary

- The Org Designer's role-editing side panel (`RoleInspector.jsx`) was resetting all of its local form fields any time the selected role's underlying node object was recreated with a new reference — even when the role's actual data hadn't changed and even while the user was still typing.
- `OrgDesigner.jsx` builds a brand-new node object for every role on every `load()` / `applyLivePatch()` / `refreshFromServer()` round trip. That includes the round trip triggered by saving one field on the *same* role (blur one field, the resulting refresh wipes any other field you'd started editing but hadn't blurred yet), and any live org-update event while an org is running — neither path is covered by the existing `isInteractingRef` "user is busy" guard, which only protects canvas drag operations.
- Reported as: "on the configuration of roles on orgs the fields seems like doesnt reflect selected role."

## Root cause

`RoleInspector`'s field-sync `useEffect` was keyed on `[node]` — the prop object's identity — rather than on which role is actually selected. Any reference churn for the same role (not just a genuine switch to a different role) re-ran the reset.

## Fix

Key the effect on `node?.id` instead of the node object itself, so local form state resets only when the selected role changes, not when its object reference merely churns from an unrelated refresh.

## Test plan

- [x] Added `RoleInspector.render.test.jsx`: reproduces the bug (typed-but-unblurred edit surviving a same-role reference refresh) — confirmed RED against the old code, GREEN after the fix.
- [x] Added a guard test confirming switching to a genuinely different role still resets the panel.
- [x] Full frontend suite: `npx vitest run` — 91/91 passing.
- [x] `go build ./...` (root) and `go build ./...` (wails-app) — both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHMRQmj4cHe2KrGcBpd3iw