### PR TITLE
fix(org-designer): fix stale Responsibilities/tool-policy text on role switch

### DIFF
--- a/wails-app/frontend/src/components/StringListField.jsx
+++ b/wails-app/frontend/src/components/StringListField.jsx
@@ -5,7 +5,18 @@
 // string-array field — currently: responsibilities, and the Org Designer's
 // tool-policy arrays (allowTools/denyTools/fileWrite/fileRead/webAllow/
 // autoApproveTools).
-export default function StringListField({ label, values, onChange, placeholder, addLabel = '+ Add' }) {
+//
+// `resetKey` should be the identity of whatever this list logically belongs
+// to (e.g. the selected role's id) — NOT derived from `values` itself. Each
+// row is an uncontrolled <input defaultValue>, and React only applies
+// `defaultValue` when a row's DOM node is first created; reusing the same
+// node across a `values` prop change (which happens whenever the list
+// length at that index doesn't change) leaves it showing stale text even
+// though `values` itself updated correctly. Folding `resetKey` into each
+// row's key forces every row to remount — and reapply its defaultValue —
+// whenever the caller's identity changes, while edits within the same
+// caller (add/remove/blur-commit) keep the same key and edit in place.
+export default function StringListField({ label, values, onChange, placeholder, addLabel = '+ Add', resetKey }) {
   const items = values || []
 
   const commit = (next) => onChange(next)
@@ -15,7 +26,7 @@ export default function StringListField({ label, values, onChange, placeholder, 
       {label && <div className="form-label">{label}</div>}
       <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
         {items.map((v, i) => (
-          <div key={i} style={{ display: 'flex', gap: 4 }}>
+          <div key={resetKey != null ? `${resetKey}:${i}` : i} style={{ display: 'flex', gap: 4 }}>
             <input
               className="form-input"
               defaultValue={v}

--- a/wails-app/frontend/src/components/StringListField.render.test.jsx
+++ b/wails-app/frontend/src/components/StringListField.render.test.jsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import React from 'react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import StringListField from './StringListField.jsx'
+
+afterEach(() => {
+  cleanup()
+})
+
+// Regression test for a real bug found via the Org Designer: selecting a
+// different role whose responsibilities list is the same length as the
+// previously-selected role's left stale text showing for some rows (e.g.
+// row 4 kept showing a THIRD role's text after switching between two other
+// roles). Root cause: each row is an uncontrolled <input defaultValue={v}>
+// keyed only by its array index. `defaultValue` is applied once, when that
+// DOM node is first created -- React reuses the same node across renders
+// whenever a row's index still exists in the new list, so a parent-driven
+// `values` prop change is silently ignored for any row whose index persists
+// across the switch, even though `values` itself is fully correct.
+it('shows the new list\'s text after values changes, even when the list length is unchanged', () => {
+  const { rerender } = render(
+    <React.StrictMode>
+      <StringListField
+        values={['role A item 1', 'role A item 2', 'role A item 3', 'role A item 4']}
+        onChange={() => {}}
+        resetKey="role-a"
+      />
+    </React.StrictMode>,
+  )
+  expect(screen.getByDisplayValue('role A item 4')).toBeInTheDocument()
+
+  rerender(
+    <React.StrictMode>
+      <StringListField
+        values={['role B item 1', 'role B item 2', 'role B item 3', 'role B item 4']}
+        onChange={() => {}}
+        resetKey="role-b"
+      />
+    </React.StrictMode>,
+  )
+
+  expect(screen.queryByDisplayValue('role A item 4')).not.toBeInTheDocument()
+  expect(screen.getByDisplayValue('role B item 1')).toBeInTheDocument()
+  expect(screen.getByDisplayValue('role B item 2')).toBeInTheDocument()
+  expect(screen.getByDisplayValue('role B item 3')).toBeInTheDocument()
+  expect(screen.getByDisplayValue('role B item 4')).toBeInTheDocument()
+})

--- a/wails-app/frontend/src/components/orgdesigner/RoleInspector.jsx
+++ b/wails-app/frontend/src/components/orgdesigner/RoleInspector.jsx
@@ -111,7 +111,23 @@ export default function RoleInspector({ node, allNodes, onPatch, onSetReportsTo,
   const [webAllow, setWebAllow] = useState([])
   const [autoApproveTools, setAutoApproveTools] = useState([])
 
+  // Remount key for the StringListField instances below (responsibilities +
+  // the six tool-policy arrays). Deliberately its OWN state, set inside this
+  // same effect rather than reading node?.id directly at the call sites:
+  // node?.id changes the INSTANT the node prop changes (same render), but
+  // the array state below (responsibilities, allowTools, ...) only catches
+  // up one render later, once this effect actually runs. Keying the remount
+  // on node?.id directly would therefore force the remount one render too
+  // early -- while the array props are still the PREVIOUS role's data --
+  // and by the time the correct data lands, the key is no longer changing,
+  // so it never reaches the (already mounted with stale defaultValue) DOM.
+  // Setting this in the same effect as the array state guarantees both land
+  // in the same batched re-render, so the remount and the correct values
+  // always arrive together.
+  const [syncedId, setSyncedId] = useState(node?.id ?? null)
+
   useEffect(() => {
+    setSyncedId(node?.id ?? null)
     setTitle(node?.title || '')
     setResponsibilities(node?.responsibilities || [])
     setRenaming(false)
@@ -340,6 +356,7 @@ export default function RoleInspector({ node, allNodes, onPatch, onSetReportsTo,
         label="Responsibilities"
         values={responsibilities}
         onChange={commitResponsibilities}
+        resetKey={syncedId}
         placeholder='e.g. "Review pull requests for security issues"'
         addLabel="+ Add responsibility"
       />
@@ -493,12 +510,12 @@ export default function RoleInspector({ node, allNodes, onPatch, onSetReportsTo,
           />
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginTop: 10 }}>
-          <StringListField label="Allow tools" values={allowTools} onChange={v => { setAllowTools(v); commitPolicy({ allowTools: v }) }} addLabel="+ Add tool" />
-          <StringListField label="Deny tools" values={denyTools} onChange={v => { setDenyTools(v); commitPolicy({ denyTools: v }) }} addLabel="+ Add tool" />
-          <StringListField label="File write globs" values={fileWrite} onChange={v => { setFileWrite(v); commitPolicy({ fileWrite: v }) }} placeholder="default: **" addLabel="+ Add glob" />
-          <StringListField label="File read globs" values={fileRead} onChange={v => { setFileRead(v); commitPolicy({ fileRead: v }) }} placeholder="default: **" addLabel="+ Add glob" />
-          <StringListField label="Web allow (hosts)" values={webAllow} onChange={v => { setWebAllow(v); commitPolicy({ webAllow: v }) }} placeholder="unset: default web access" addLabel="+ Add host" />
-          <StringListField label="Auto-approve tools" values={autoApproveTools} onChange={v => { setAutoApproveTools(v); commitPolicy({ autoApproveTools: v }) }} placeholder="skips the human-approval pause" addLabel="+ Add tool" />
+          <StringListField label="Allow tools" values={allowTools} onChange={v => { setAllowTools(v); commitPolicy({ allowTools: v }) }} resetKey={syncedId} addLabel="+ Add tool" />
+          <StringListField label="Deny tools" values={denyTools} onChange={v => { setDenyTools(v); commitPolicy({ denyTools: v }) }} resetKey={syncedId} addLabel="+ Add tool" />
+          <StringListField label="File write globs" values={fileWrite} onChange={v => { setFileWrite(v); commitPolicy({ fileWrite: v }) }} resetKey={syncedId} placeholder="default: **" addLabel="+ Add glob" />
+          <StringListField label="File read globs" values={fileRead} onChange={v => { setFileRead(v); commitPolicy({ fileRead: v }) }} resetKey={syncedId} placeholder="default: **" addLabel="+ Add glob" />
+          <StringListField label="Web allow (hosts)" values={webAllow} onChange={v => { setWebAllow(v); commitPolicy({ webAllow: v }) }} resetKey={syncedId} placeholder="unset: default web access" addLabel="+ Add host" />
+          <StringListField label="Auto-approve tools" values={autoApproveTools} onChange={v => { setAutoApproveTools(v); commitPolicy({ autoApproveTools: v }) }} resetKey={syncedId} placeholder="skips the human-approval pause" addLabel="+ Add tool" />
         </div>
       </section>
 

--- a/wails-app/frontend/src/components/orgdesigner/RoleInspector.render.test.jsx
+++ b/wails-app/frontend/src/components/orgdesigner/RoleInspector.render.test.jsx
@@ -26,6 +26,24 @@ function makeNode(overrides = {}) {
   }
 }
 
+// Wrapped in StrictMode throughout -- this app is run via `wails dev`
+// (development), which mounts every component under StrictMode, and this
+// exact file already caught one bug (OrgsPanel) that only reproduced there.
+function renderInspector(props) {
+  return render(
+    <React.StrictMode>
+      <RoleInspector {...props} />
+    </React.StrictMode>,
+  )
+}
+function rerenderInspector(rerender, props) {
+  return rerender(
+    <React.StrictMode>
+      <RoleInspector {...props} />
+    </React.StrictMode>,
+  )
+}
+
 // Regression test for the reported bug: "the fields seem like they don't
 // reflect the selected role." Root cause: RoleInspector's field-sync effect
 // keys on the `node` PROP's object identity ([node] dependency), but
@@ -40,9 +58,7 @@ function makeNode(overrides = {}) {
 // the moment any such refresh fires while that same role stays selected.
 it('keeps an in-progress (not yet blurred) edit when the same role re-renders with a new object reference', () => {
   const nodeA = makeNode()
-  const { rerender } = render(
-    <RoleInspector node={nodeA} allNodes={[nodeA]} onPatch={() => {}} />,
-  )
+  const { rerender } = renderInspector({ node: nodeA, allNodes: [nodeA], onPatch: () => {} })
 
   const modelInput = screen.getByPlaceholderText('claude-sonnet-4-5')
   fireEvent.change(modelInput, { target: { value: 'claude-opus-5' } })
@@ -51,9 +67,7 @@ it('keeps an in-progress (not yet blurred) edit when the same role re-renders wi
   // Same role, same underlying data, but a fresh object reference -- exactly
   // what applyLivePatch/refreshFromServer produce for an "unchanged" role.
   const nodeAAgain = makeNode()
-  rerender(
-    <RoleInspector node={nodeAAgain} allNodes={[nodeAAgain]} onPatch={() => {}} />,
-  )
+  rerenderInspector(rerender, { node: nodeAAgain, allNodes: [nodeAAgain], onPatch: () => {} })
 
   expect(modelInput).toHaveValue('claude-opus-5')
 })
@@ -62,17 +76,49 @@ it('keeps an in-progress (not yet blurred) edit when the same role re-renders wi
 // different role must still reset the panel to that role's own values.
 it('resets fields when a different role becomes selected', () => {
   const nodeA = makeNode()
-  const { rerender } = render(
-    <RoleInspector node={nodeA} allNodes={[nodeA]} onPatch={() => {}} />,
-  )
+  const { rerender } = renderInspector({ node: nodeA, allNodes: [nodeA], onPatch: () => {} })
   const modelInput = screen.getByPlaceholderText('claude-sonnet-4-5')
   fireEvent.change(modelInput, { target: { value: 'unsaved-edit' } })
 
   const nodeB = makeNode({ id: 'editor', title: 'Editor', rest: { adapter_config: { model: 'gpt-3.5' } } })
-  rerender(
-    <RoleInspector node={nodeB} allNodes={[nodeB]} onPatch={() => {}} />,
-  )
+  rerenderInspector(rerender, { node: nodeB, allNodes: [nodeB], onPatch: () => {} })
 
   expect(screen.getByPlaceholderText('claude-sonnet-4-5')).toHaveValue('gpt-3.5')
   expect(screen.getByDisplayValue('Editor')).toBeInTheDocument()
+})
+
+// Regression test for a second, distinct bug found via manual testing of the
+// fix above: title/id/label correctly updated on role switch, but
+// Responsibilities did not, because it's rendered by StringListField as
+// uncontrolled <input defaultValue> rows keyed only by array index --
+// `defaultValue` only applies when a row's DOM node is first created, so
+// switching to another role whose list is the same length reuses the same
+// row nodes and leaves them showing the previous role's text. Fixed by
+// threading a `syncedId` (set inside the same effect/batch as the
+// responsibilities/tool-policy array state itself, NOT read directly from
+// node.id at the call site -- node.id changes one render before those
+// arrays catch up, which forces the remount too early and misses the
+// correct data) through to StringListField's `resetKey`, so every row
+// remounts -- and reapplies defaultValue from the right data -- in the same
+// render the new role's arrays actually land.
+it('updates responsibilities text when switching to a role with a same-length list', () => {
+  const nodeA = makeNode({
+    id: 'researcher',
+    responsibilities: ['Verify claims', 'Produce findings', 'Identify audiences', 'Flag risks'],
+  })
+  const { rerender } = renderInspector({ node: nodeA, allNodes: [nodeA], onPatch: () => {} })
+  expect(screen.getByDisplayValue('Flag risks')).toBeInTheDocument()
+
+  const nodeB = makeNode({
+    id: 'narrative-lead',
+    title: 'Narrative Lead',
+    responsibilities: ['Draft hooks', 'Draft posts', 'Design prompts', 'Hand off copy'],
+  })
+  rerenderInspector(rerender, { node: nodeB, allNodes: [nodeB], onPatch: () => {} })
+
+  expect(screen.queryByDisplayValue('Flag risks')).not.toBeInTheDocument()
+  expect(screen.getByDisplayValue('Draft hooks')).toBeInTheDocument()
+  expect(screen.getByDisplayValue('Draft posts')).toBeInTheDocument()
+  expect(screen.getByDisplayValue('Design prompts')).toBeInTheDocument()
+  expect(screen.getByDisplayValue('Hand off copy')).toBeInTheDocument()
 })


### PR DESCRIPTION
## Summary

This is a **second, distinct bug** found while manually verifying #69 (merged, v0.42.1) — #69 was real and correct (Title/Label/id now demonstrably update on role switch, confirmed in the reporter's own screenshots), but its tests never asserted on the one field group in the panel that's rendered differently, so this second bug slipped through.

- Selecting a different role in the Org Designer's role panel correctly updated Title/Label/id, but **Responsibilities kept showing the previously-selected role's text** when the two roles' lists happened to be the same length. Screenshots showed "Election & Evidence Researcher" and "LinkedIn Narrative Lead" both displaying the exact same four responsibility lines.
- Root cause: `Responsibilities` (and the six tool-policy arrays — Allow tools, Deny tools, File write/read globs, Web allow, Auto-approve tools) are rendered by `StringListField` as uncontrolled `<input defaultValue>` rows keyed only by array index. `defaultValue` is applied once, when a row's DOM node is first created — React reuses the same node whenever a row's index still exists in the new list, so the displayed text stays stale even though the `values` prop is fully correct underneath.

## Fix

- `StringListField` now accepts a `resetKey`, folded into each row's key so changing it forces every row to remount (and reapply `defaultValue`), while normal in-list editing (add/remove/blur-commit) keeps the same key and edits in place.
- The obvious first attempt — passing `node.id` directly as `resetKey` — turned out to be incomplete: `node.id` changes the instant the `node` prop changes (same render), but the responsibilities/tool-policy array state only catches up one render later, via `RoleInspector`'s existing field-sync effect. Keying on `node.id` directly forced the remount one render too early, while the arrays were still the previous role's data — and by the time the correct data landed, the key was no longer changing, so it never reached the DOM. Fixed with a dedicated `syncedId` state set inside that same effect (same batch as the array state), so the remount and the correct values always land in the same render.

## Test plan

- [x] `StringListField.render.test.jsx` (new): isolates the root cause directly — same-length list swap, same index positions, asserts the new text replaces the old.
- [x] `RoleInspector.render.test.jsx`: added a case reproducing the exact reported symptom (two same-length responsibility lists across a role switch), plus wrapped all three tests in this file (including the two from #69) in `React.StrictMode` to match `wails dev`, the environment the bug was actually reported in.
- [x] Full frontend suite: `npx vitest run` — 93/93 passing, StrictMode included.
- [x] `go build ./...` (root) and `go build ./...` (wails-app) — both clean.
- [x] Verified directly against the raw DOM (not just RTL matchers) that the fix produces the correct displayed text, not just a correct `values` prop.

## Known follow-up (not fixed here, flagged for visibility)

Removing a row from the middle of a `StringListField` list produces the right underlying array, but surviving rows keep their `${syncedId}:index}` keys, so the reused DOM nodes can still display pre-removal text for a moment, and a subsequent blur on that row could write stale DOM text back into the saved data. This is a pre-existing index-key + `defaultValue` issue, unrelated to the bug reported here — happy to take it as a separate task if it's hit in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHMRQmj4cHe2KrGcBpd3iw