### PR TITLE
New profile modal with icon + monomind project picker, .monoagent data isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ edge_passwords.csv
 .monomind/logs/
 .monomind/orgs/
 .monomind/state/
+.monomind/graph/.rebuild-lock
 
 # Personal AI-assistant tool configuration (per-machine setup, not shared
 # repo content) — same treatment as .claude/ above.

--- a/data/migrations/039_profiles_icon.sql
+++ b/data/migrations/039_profiles_icon.sql
@@ -1,0 +1,13 @@
+-- 039_profiles_icon.sql
+--
+-- Lets a profile carry an icon (an id into the shared agent-avatars.json
+-- manifest, the same one the Org Designer's role icons already use), picked
+-- at creation time. Empty (the default) means "no icon chosen" — the
+-- frontend falls back to a generic placeholder, exactly like an icon-less
+-- org role already does today.
+--
+-- ALTER TABLE ... ADD COLUMN cannot be guarded with IF NOT EXISTS in SQL.
+-- The column addition therefore lives in storage.ReconcileSchema (see
+-- reconcileProfilesIcon), which PRAGMA-checks the actual table shape on
+-- every database open — same shape as 028_profiles_root_dir.sql. This file
+-- reserves the version slot and records the intent.

--- a/internal/profiledir/profiledir.go
+++ b/internal/profiledir/profiledir.go
@@ -60,10 +60,27 @@ func Root(db *sql.DB, profileID string) string {
 	return defaultRoot(profileID)
 }
 
-// VaultDir returns <profile root>/vault/, where this profile's registered
-// files/images live.
+// IsDefaultManaged reports whether profileID currently resolves to the
+// default profile root (no profiles.root_dir override) rather than a
+// custom folder such as an existing coding project. Callers use this to
+// decide whether the TaxonomyFolders convention and its stricter default
+// org fileWrite policy should apply — a custom root_dir is explicitly
+// supported for pointing a profile at existing project structure (see
+// wails-app/app.go's validateFolderChoice), so that case is deliberately
+// left unrestricted.
+func IsDefaultManaged(db *sql.DB, profileID string) bool {
+	return Root(db, profileID) == defaultRoot(profileID)
+}
+
+// VaultDir returns <profile root>/.monoagent/vault/, where this profile's
+// registered files/images live. Nested under .monoagent/ (not directly in
+// root) so that everything monoagent itself owns is a single, gitignorable
+// unit when root_dir points at a real coding project — distinct from
+// .monomind/, which belongs to the separate monomind tool's own convention,
+// and from the TaxonomyFolders (docs/, workingdocs/, assets/, codes/),
+// which are deliberately user/agent-visible content at the project root.
 func VaultDir(db *sql.DB, profileID string) string {
-	return filepath.Join(Root(db, profileID), "vault")
+	return filepath.Join(Root(db, profileID), ".monoagent", "vault")
 }
 
 // MonomindDir returns <profile root>/.monomind/, the project root monomind
@@ -73,9 +90,37 @@ func MonomindDir(db *sql.DB, profileID string) string {
 	return filepath.Join(Root(db, profileID), ".monomind")
 }
 
-// EnsureLayout creates a profile's folder structure (root, vault, .monomind)
-// if it doesn't already exist. Safe to call repeatedly. Rejects invalid
-// profile IDs before any path is joined or created.
+// TaxonomyFolder names one of a profile's standard content subfolders and
+// documents its intended purpose, so callers (chat/org system prompts,
+// default fileWrite policies) can generate guidance from one source of
+// truth instead of hand-copying folder names.
+type TaxonomyFolder struct {
+	Name    string // relative to Root(db, profileID), no trailing slash
+	Purpose string // one sentence, written for an agent's own guidance text
+}
+
+// TaxonomyFolders are the standard subfolders new content -- especially
+// content an agent (chat or org) creates -- should default into. Unlike
+// VaultDir/MonomindDir, these are not created by EnsureLayout: see its own
+// doc comment for why.
+var TaxonomyFolders = []TaxonomyFolder{
+	{Name: "docs", Purpose: "Finished, stable reference documentation — specs, write-ups, README-style content meant to be read later, not actively being drafted."},
+	{Name: "workingdocs", Purpose: "In-progress drafts, notes, and scratch working documents not yet finished — the staging area before something graduates to docs/."},
+	{Name: "assets", Purpose: "Ad hoc images, charts, or other binary/media files created or fetched while doing a task, that don't need full vault registration the way vault/ items do."},
+	{Name: "codes", Purpose: "Scripts, snippets, or small programs written to accomplish a task — not vault content, not internal monomind state."},
+}
+
+// EnsureLayout creates a profile's folder structure (root, .monoagent/vault,
+// .monomind) if it doesn't already exist. Safe to call repeatedly. Rejects
+// invalid profile IDs before any path is joined or created.
+//
+// Deliberately does NOT create TaxonomyFolders: EnsureLayout also runs as a
+// startup migration pass over every existing profile, and materializing 4
+// new folders in every profile -- including ones pointed at a real coding
+// project via root_dir -- would violate the "only .monoagent/ and .monomind/"
+// promise validateFolderChoice (wails-app/app.go) documents and relies on.
+// Taxonomy folders are created lazily, the first time something actually
+// writes into them (same as vault/documents/ already is).
 func EnsureLayout(db *sql.DB, profileID string) error {
 	if !ValidProfileID(profileID) {
 		return fmt.Errorf("invalid profile id %q: must be non-empty and contain no '/', '\\', or '..'", profileID)
@@ -85,7 +130,25 @@ func EnsureLayout(db *sql.DB, profileID string) error {
 			return err
 		}
 	}
+	ensureMonoagentGitignore(db, profileID)
 	return nil
+}
+
+// ensureMonoagentGitignore writes a blanket-ignore .gitignore into
+// <root>/.monoagent/ the first time it's missing — the actual reason this
+// data lives under .monoagent/ at all: so it disappears from `git
+// status`/`git add` as a single unit when root_dir points at a real,
+// git-tracked coding project. Never overwrites an existing file (a user is
+// free to edit or delete it — EnsureLayout runs on every startup for every
+// profile), and never fails EnsureLayout: a missing .gitignore leaves the
+// folder fully usable, just untidy in `git status`, which isn't worth
+// failing profile setup over.
+func ensureMonoagentGitignore(db *sql.DB, profileID string) {
+	path := filepath.Join(Root(db, profileID), ".monoagent", ".gitignore")
+	if _, err := os.Stat(path); err == nil || !os.IsNotExist(err) {
+		return
+	}
+	_ = os.WriteFile(path, []byte("*\n"), 0600)
 }
 
 // Exists reports whether a profile's folder has already been created —

--- a/internal/profiledir/profiledir_test.go
+++ b/internal/profiledir/profiledir_test.go
@@ -1,9 +1,13 @@
 package profiledir
 
 import (
+	"database/sql"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	_ "modernc.org/sqlite"
 )
 
 func TestValidProfileID(t *testing.T) {
@@ -31,7 +35,7 @@ func TestRoot_DefaultJoin(t *testing.T) {
 	if got != want {
 		t.Errorf("Root(nil, \"work\") = %q, want %q", got, want)
 	}
-	if VaultDir(nil, "work") != filepath.Join(want, "vault") {
+	if VaultDir(nil, "work") != filepath.Join(want, ".monoagent", "vault") {
 		t.Errorf("VaultDir mismatch: %q", VaultDir(nil, "work"))
 	}
 	if MonomindDir(nil, "work") != filepath.Join(want, ".monomind") {
@@ -88,5 +92,112 @@ func TestEnsureLayout(t *testing.T) {
 	// Idempotent.
 	if err := EnsureLayout(nil, "work"); err != nil {
 		t.Fatalf("EnsureLayout (repeat): %v", err)
+	}
+}
+
+// TestEnsureLayout_WritesMonoagentGitignore covers the actual reason this
+// data lives under .monoagent/ at all (per the user's own request): so it
+// can be gitignored as a single unit when root_dir points at a real,
+// git-tracked coding project. Without a .gitignore inside .monoagent/
+// itself, every profile pointed at a real repo would show it as untracked
+// noise in `git status` forever.
+func TestEnsureLayout_WritesMonoagentGitignore(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	if err := EnsureLayout(nil, "work"); err != nil {
+		t.Fatalf("EnsureLayout: %v", err)
+	}
+
+	gitignorePath := filepath.Join(Root(nil, "work"), ".monoagent", ".gitignore")
+	got, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatalf("reading .monoagent/.gitignore: %v", err)
+	}
+	if string(got) != "*\n" {
+		t.Errorf(".monoagent/.gitignore content = %q, want %q", got, "*\n")
+	}
+}
+
+// TestEnsureLayout_NeverOverwritesExistingMonoagentGitignore: a user is free
+// to hand-edit or replace .monoagent/.gitignore (e.g. to un-ignore a
+// specific file), and EnsureLayout runs on every startup for every profile
+// — it must never clobber that customization back to the default content.
+func TestEnsureLayout_NeverOverwritesExistingMonoagentGitignore(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	if err := EnsureLayout(nil, "work"); err != nil {
+		t.Fatalf("EnsureLayout: %v", err)
+	}
+	gitignorePath := filepath.Join(Root(nil, "work"), ".monoagent", ".gitignore")
+	custom := "*\n!keep-this.txt\n"
+	if err := os.WriteFile(gitignorePath, []byte(custom), 0600); err != nil {
+		t.Fatalf("seed custom .gitignore: %v", err)
+	}
+
+	if err := EnsureLayout(nil, "work"); err != nil {
+		t.Fatalf("EnsureLayout (repeat): %v", err)
+	}
+
+	got, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatalf("reading .monoagent/.gitignore: %v", err)
+	}
+	if string(got) != custom {
+		t.Errorf("EnsureLayout overwrote a customized .gitignore: got %q, want %q", got, custom)
+	}
+}
+
+func TestIsDefaultManaged(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	if !IsDefaultManaged(nil, "work") {
+		t.Error("nil db (no override possible) should report default-managed")
+	}
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`CREATE TABLE profiles (id TEXT PRIMARY KEY, root_dir TEXT)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO profiles (id, root_dir) VALUES ('default-profile', '')`); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO profiles (id, root_dir) VALUES ('custom-profile', ?)`, filepath.Join(home, "my-project")); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	if !IsDefaultManaged(db, "default-profile") {
+		t.Error("a profile with no root_dir override should report default-managed")
+	}
+	if IsDefaultManaged(db, "custom-profile") {
+		t.Error("a profile with a root_dir override should NOT report default-managed")
+	}
+}
+
+func TestTaxonomyFoldersHaveNonEmptyUniqueNames(t *testing.T) {
+	if len(TaxonomyFolders) == 0 {
+		t.Fatal("TaxonomyFolders is empty")
+	}
+	seen := map[string]bool{}
+	for _, f := range TaxonomyFolders {
+		if f.Name == "" {
+			t.Errorf("TaxonomyFolder has empty Name (Purpose: %q)", f.Purpose)
+		}
+		if f.Purpose == "" {
+			t.Errorf("TaxonomyFolder %q has empty Purpose", f.Name)
+		}
+		if seen[f.Name] {
+			t.Errorf("duplicate TaxonomyFolder name %q", f.Name)
+		}
+		seen[f.Name] = true
 	}
 }

--- a/internal/storage/reconcile.go
+++ b/internal/storage/reconcile.go
@@ -37,6 +37,9 @@ func (d *Database) ReconcileSchema(ctx context.Context) error {
 	if err := d.reconcileProfilesRootDir(ctx); err != nil {
 		return err
 	}
+	if err := d.reconcileProfilesIcon(ctx); err != nil {
+		return err
+	}
 	return d.reconcileExecutionProfiles(ctx)
 }
 
@@ -173,6 +176,62 @@ func (d *Database) reconcileProfilesRootDir(ctx context.Context) error {
 			return fmt.Errorf("storage: reconcile: adding profiles.root_dir: %w", err)
 		}
 		log.Printf("storage: reconcile: added profiles.root_dir column")
+	}
+
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return fmt.Errorf("storage: reconcile: commit: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+// reconcileProfilesIcon adds profiles.icon (the 039 migration's column)
+// when missing — same ALTER-guard shape as reconcileProfilesRootDir, since
+// SQLite still can't express "ADD COLUMN IF NOT EXISTS". No-op when the
+// column is already there. Empty string means "no icon chosen", matching
+// how an empty root_dir already means "use the default location".
+func (d *Database) reconcileProfilesIcon(ctx context.Context) error {
+	exists, err := d.tableExists(ctx, "profiles")
+	if err != nil {
+		return fmt.Errorf("storage: reconcile: checking profiles: %w", err)
+	}
+	if !exists {
+		return nil
+	}
+	hasIcon, err := d.columnExists(ctx, "profiles", "icon")
+	if err != nil {
+		return fmt.Errorf("storage: reconcile: inspecting profiles: %w", err)
+	}
+	if hasIcon {
+		return nil
+	}
+
+	conn, err := d.DB.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("storage: reconcile: get conn: %w", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return fmt.Errorf("storage: reconcile: begin tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+		}
+	}()
+
+	// Re-check under the lock, mirroring reconcileProfilesRootDir.
+	hasIcon, err = columnExistsOn(ctx, conn, "profiles", "icon")
+	if err != nil {
+		return fmt.Errorf("storage: reconcile: re-inspecting profiles: %w", err)
+	}
+	if !hasIcon {
+		if _, err := conn.ExecContext(ctx, `ALTER TABLE profiles ADD COLUMN icon TEXT NOT NULL DEFAULT ''`); err != nil {
+			return fmt.Errorf("storage: reconcile: adding profiles.icon: %w", err)
+		}
+		log.Printf("storage: reconcile: added profiles.icon column")
 	}
 
 	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {

--- a/internal/storage/reconcile_test.go
+++ b/internal/storage/reconcile_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"log"
 	"os"
 	"path/filepath"
@@ -294,6 +295,89 @@ func TestReconcileSchema_BackfillsExecutionProfiles(t *testing.T) {
 	}
 	if got := profile("e-stay"); got != "default" {
 		t.Fatalf("e-stay profile changed on second pass: %q", got)
+	}
+}
+
+// TestReconcileProfilesIcon_AddsMissingColumn mirrors the existing
+// root_dir column addition test technique: a plain ApplyMigrations() on a
+// fresh database already leaves profiles.icon in place (ApplyMigrations
+// itself calls ReconcileSchema at the end, same as every real DB-open path
+// does), so exercising the "column genuinely missing" case needs a
+// hand-built profiles table predating migration 039, the same way
+// reconcileProfilesRootDir's own gap would only show up on a database that
+// predates 028. reconcileProfilesIcon is called directly (this test lives
+// in package storage) against that raw shape.
+func TestReconcileProfilesIcon_AddsMissingColumn(t *testing.T) {
+	rawDB, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "old-shape.db"))
+	if err != nil {
+		t.Fatalf("open raw db: %v", err)
+	}
+	defer rawDB.Close()
+	if _, err := rawDB.Exec(`CREATE TABLE profiles (
+		id TEXT PRIMARY KEY, name TEXT NOT NULL, created_at TEXT NOT NULL,
+		root_dir TEXT NOT NULL DEFAULT ''
+	)`); err != nil {
+		t.Fatalf("creating old-shape profiles table: %v", err)
+	}
+	if _, err := rawDB.Exec(`INSERT INTO profiles (id, name, created_at) VALUES ('p1', 'Work', '2026-01-01T00:00:00Z')`); err != nil {
+		t.Fatalf("seeding profile: %v", err)
+	}
+	db := &Database{DB: rawDB}
+
+	if hasColumn(t, db, "profiles", "icon") {
+		t.Fatal("test setup bug: old-shape profiles table already has icon")
+	}
+
+	if err := db.reconcileProfilesIcon(context.Background()); err != nil {
+		t.Fatalf("reconcileProfilesIcon: %v", err)
+	}
+	if !hasColumn(t, db, "profiles", "icon") {
+		t.Fatal("expected profiles.icon to exist after reconcileProfilesIcon")
+	}
+	var icon string
+	if err := db.DB.QueryRow(`SELECT icon FROM profiles WHERE id = 'p1'`).Scan(&icon); err != nil {
+		t.Fatalf("reading backfilled icon: %v", err)
+	}
+	if icon != "" {
+		t.Fatalf("icon = %q, want empty default for a pre-existing profile", icon)
+	}
+
+	// Idempotent: no error, existing data untouched.
+	if err := db.reconcileProfilesIcon(context.Background()); err != nil {
+		t.Fatalf("second reconcileProfilesIcon: %v", err)
+	}
+}
+
+// TestReconcileSchema_LeavesProfilesIconInPlace confirms the real end-to-end
+// path: a fresh database opened normally already has profiles.icon by the
+// time ApplyMigrations returns, and a value written to it survives a second
+// ReconcileSchema call untouched.
+func TestReconcileSchema_LeavesProfilesIconInPlace(t *testing.T) {
+	db, err := NewDatabase(filepath.Join(t.TempDir(), "profiles-icon.db"))
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+	defer db.DB.Close()
+	if err := db.ApplyMigrations(); err != nil {
+		t.Fatalf("ApplyMigrations: %v", err)
+	}
+	if !hasColumn(t, db, "profiles", "icon") {
+		t.Fatal("expected profiles.icon to exist after ApplyMigrations")
+	}
+
+	if _, err := db.DB.Exec(`INSERT INTO profiles (id, name, created_at, icon) VALUES ('p1', 'Work', '2026-01-01T00:00:00Z', 'coder')`); err != nil {
+		t.Fatalf("inserting a profile with an icon: %v", err)
+	}
+
+	if err := db.ReconcileSchema(context.Background()); err != nil {
+		t.Fatalf("ReconcileSchema: %v", err)
+	}
+	var icon string
+	if err := db.DB.QueryRow(`SELECT icon FROM profiles WHERE id = 'p1'`).Scan(&icon); err != nil {
+		t.Fatalf("reading icon after reconcile: %v", err)
+	}
+	if icon != "coder" {
+		t.Fatalf("icon = %q, want %q", icon, "coder")
 	}
 }
 

--- a/internal/vault/movefiles_test.go
+++ b/internal/vault/movefiles_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/monoes/mono-agent/internal/profiledir"
 )
 
 func TestMoveFiles_MovesAndUpdatesPaths(t *testing.T) {
@@ -96,5 +98,317 @@ func TestMoveFiles_OnlyMovesMatchingProfile(t *testing.T) {
 	}
 	if _, err := os.Stat(pathB); err != nil {
 		t.Fatalf("profile p2's file was moved too: %v", err)
+	}
+}
+
+// setHomeForTest points profiledir's default-root resolution at a fresh temp
+// dir, mirroring internal/profiledir/profiledir_test.go's own pattern —
+// MigrateVaultDirIntoMonoagent resolves paths via profiledir.Root/VaultDir,
+// which fall back to $HOME/.monoagent/profiles/<id>/ when db has no
+// profiles.root_dir override (newVaultTestDB's DB has no profiles table at
+// all, so Root's override lookup errors and falls through to the default —
+// exactly the case this exercises).
+func setHomeForTest(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	return home
+}
+
+func TestMigrateVaultDirIntoMonoagent_MovesFromOldPerProfilePathAndRemovesEmptyDir(t *testing.T) {
+	setHomeForTest(t)
+	db := newVaultTestDB(t)
+
+	root := profiledir.Root(db, "p1")
+	oldDir := filepath.Join(root, "vault")
+	if err := os.MkdirAll(oldDir, 0700); err != nil {
+		t.Fatalf("seed old vault dir: %v", err)
+	}
+	srcPath := filepath.Join(oldDir, "img-001.png")
+	if err := os.WriteFile(srcPath, []byte("fake image bytes"), 0600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO vault_images (id, path, filename, profile_id) VALUES ('img-001', ?, 'img-001.png', 'p1')`, srcPath); err != nil {
+		t.Fatalf("seed row: %v", err)
+	}
+
+	moved, errs := MigrateVaultDirIntoMonoagent(context.Background(), db, "p1")
+	if len(errs) != 0 {
+		t.Fatalf("MigrateVaultDirIntoMonoagent errors: %v", errs)
+	}
+	if moved != 1 {
+		t.Fatalf("moved = %d, want 1", moved)
+	}
+
+	newPath := filepath.Join(profiledir.VaultDir(db, "p1"), "img-001.png")
+	if _, err := os.Stat(newPath); err != nil {
+		t.Fatalf("file not at new .monoagent/vault path: %v", err)
+	}
+	var dbPath string
+	if err := db.QueryRow(`SELECT path FROM vault_images WHERE id = 'img-001'`).Scan(&dbPath); err != nil {
+		t.Fatalf("reading updated path: %v", err)
+	}
+	if dbPath != newPath {
+		t.Fatalf("db path = %q, want %q", dbPath, newPath)
+	}
+	if _, err := os.Stat(oldDir); !os.IsNotExist(err) {
+		t.Fatalf("old vault/ dir should have been removed once empty, stat err = %v", err)
+	}
+}
+
+func TestMigrateVaultDirIntoMonoagent_SecondCallIsNoOp(t *testing.T) {
+	setHomeForTest(t)
+	db := newVaultTestDB(t)
+
+	root := profiledir.Root(db, "p1")
+	oldDir := filepath.Join(root, "vault")
+	os.MkdirAll(oldDir, 0700)
+	srcPath := filepath.Join(oldDir, "img-001.png")
+	os.WriteFile(srcPath, []byte("x"), 0600)
+	db.Exec(`INSERT INTO vault_images (id, path, filename, profile_id) VALUES ('img-001', ?, 'img-001.png', 'p1')`, srcPath)
+
+	if moved, errs := MigrateVaultDirIntoMonoagent(context.Background(), db, "p1"); moved != 1 || len(errs) != 0 {
+		t.Fatalf("first call: moved=%d errs=%v", moved, errs)
+	}
+
+	moved, errs := MigrateVaultDirIntoMonoagent(context.Background(), db, "p1")
+	if len(errs) != 0 {
+		t.Fatalf("second call errors: %v", errs)
+	}
+	if moved != 0 {
+		t.Fatalf("second call moved = %d, want 0 (already migrated)", moved)
+	}
+}
+
+func TestMigrateVaultDirIntoMonoagent_LeavesNonEmptyOldDirIfUnknownFileRemains(t *testing.T) {
+	setHomeForTest(t)
+	db := newVaultTestDB(t)
+
+	root := profiledir.Root(db, "p1")
+	oldDir := filepath.Join(root, "vault")
+	os.MkdirAll(oldDir, 0700)
+	trackedPath := filepath.Join(oldDir, "img-001.png")
+	os.WriteFile(trackedPath, []byte("tracked"), 0600)
+	db.Exec(`INSERT INTO vault_images (id, path, filename, profile_id) VALUES ('img-001', ?, 'img-001.png', 'p1')`, trackedPath)
+	// A file the DB never knew about (e.g. left over by hand) — must never
+	// be silently discarded.
+	strayPath := filepath.Join(oldDir, "stray-notes.txt")
+	os.WriteFile(strayPath, []byte("do not delete me"), 0600)
+
+	moved, errs := MigrateVaultDirIntoMonoagent(context.Background(), db, "p1")
+	if len(errs) != 0 || moved != 1 {
+		t.Fatalf("moved=%d errs=%v, want moved=1 no errs", moved, errs)
+	}
+	if _, err := os.Stat(oldDir); err != nil {
+		t.Fatalf("old vault/ dir should still exist (non-empty): %v", err)
+	}
+	if _, err := os.Stat(strayPath); err != nil {
+		t.Fatalf("stray untracked file must be left in place: %v", err)
+	}
+}
+
+func TestMigrateVaultDirIntoMonoagent_NoOldDirIsCleanNoOp(t *testing.T) {
+	setHomeForTest(t)
+	db := newVaultTestDB(t)
+
+	moved, errs := MigrateVaultDirIntoMonoagent(context.Background(), db, "fresh-profile")
+	if len(errs) != 0 || moved != 0 {
+		t.Fatalf("moved=%d errs=%v, want moved=0 no errs for a profile with no legacy vault dir", moved, errs)
+	}
+}
+
+func TestMoveDocumentFiles_MovesAndUpdatesPaths(t *testing.T) {
+	db := newVaultTestDB(t)
+	fromDir := t.TempDir()
+	toDir := filepath.Join(t.TempDir(), "dest")
+
+	srcPath := filepath.Join(fromDir, "doc-001.pdf")
+	content := []byte("fake pdf bytes")
+	if err := os.WriteFile(srcPath, content, 0600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO vault_documents (id, path, filename, profile_id, source) VALUES ('doc-001', ?, 'doc-001.pdf', 'p1', 'upload')`, srcPath); err != nil {
+		t.Fatalf("seed row: %v", err)
+	}
+
+	moved, errs := MoveDocumentFiles(context.Background(), db, "p1", fromDir, toDir)
+	if len(errs) != 0 {
+		t.Fatalf("MoveDocumentFiles errors: %v", errs)
+	}
+	if moved != 1 {
+		t.Fatalf("moved = %d, want 1", moved)
+	}
+
+	destPath := filepath.Join(toDir, "doc-001.pdf")
+	if _, err := os.Stat(srcPath); !os.IsNotExist(err) {
+		t.Fatalf("source file still exists at %s", srcPath)
+	}
+	got, err := os.ReadFile(destPath)
+	if err != nil {
+		t.Fatalf("reading moved file: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("moved file content mismatch: got %q want %q", got, content)
+	}
+
+	var dbPath string
+	if err := db.QueryRow(`SELECT path FROM vault_documents WHERE id = 'doc-001'`).Scan(&dbPath); err != nil {
+		t.Fatalf("reading updated path: %v", err)
+	}
+	if dbPath != destPath {
+		t.Fatalf("db path = %q, want %q", dbPath, destPath)
+	}
+}
+
+// TestMoveDocumentFiles_UsesPathBasenameAvoidingFilenameCollisions is the
+// regression test for a real hazard specific to vault_documents:
+// RegisterDocument stores the ORIGINAL uploaded filename in the `filename`
+// column (e.g. "resume.pdf") while the actual on-disk/DB path uses a
+// unique id-based name (e.g. "doc-001.pdf") -- see RegisterDocument's
+// destPath construction. Two different uploads named identically by the
+// user ("resume.pdf") therefore have distinct paths but an IDENTICAL
+// filename column. Building the destination name from the filename column
+// (as MoveFiles' shared engine originally did) would make both rows
+// resolve to the same destPath, and the second os.Rename would silently
+// clobber the first with no reported error -- a real, silent data-loss
+// hazard. Building it from the CURRENT path's own basename instead (which
+// is already unique, since it's what's on disk right now) avoids the
+// collision entirely, for both tables uniformly.
+func TestMoveDocumentFiles_UsesPathBasenameAvoidingFilenameCollisions(t *testing.T) {
+	db := newVaultTestDB(t)
+	fromDir := t.TempDir()
+	toDir := t.TempDir()
+
+	path1 := filepath.Join(fromDir, "doc-001.pdf")
+	path2 := filepath.Join(fromDir, "doc-002.pdf")
+	os.WriteFile(path1, []byte("first upload"), 0600)
+	os.WriteFile(path2, []byte("second upload"), 0600)
+	// Both rows share the SAME original filename -- the collision-prone case.
+	db.Exec(`INSERT INTO vault_documents (id, path, filename, profile_id, source) VALUES ('doc-001', ?, 'resume.pdf', 'p1', 'upload')`, path1)
+	db.Exec(`INSERT INTO vault_documents (id, path, filename, profile_id, source) VALUES ('doc-002', ?, 'resume.pdf', 'p1', 'upload')`, path2)
+
+	moved, errs := MoveDocumentFiles(context.Background(), db, "p1", fromDir, toDir)
+	if len(errs) != 0 {
+		t.Fatalf("MoveDocumentFiles errors: %v", errs)
+	}
+	if moved != 2 {
+		t.Fatalf("moved = %d, want 2", moved)
+	}
+
+	got1, err := os.ReadFile(filepath.Join(toDir, "doc-001.pdf"))
+	if err != nil {
+		t.Fatalf("doc-001.pdf missing after move: %v", err)
+	}
+	if string(got1) != "first upload" {
+		t.Fatalf("doc-001.pdf content = %q, want %q (collision clobbered it)", got1, "first upload")
+	}
+	got2, err := os.ReadFile(filepath.Join(toDir, "doc-002.pdf"))
+	if err != nil {
+		t.Fatalf("doc-002.pdf missing after move: %v", err)
+	}
+	if string(got2) != "second upload" {
+		t.Fatalf("doc-002.pdf content = %q, want %q", got2, "second upload")
+	}
+
+	var dbPath1, dbPath2 string
+	db.QueryRow(`SELECT path FROM vault_documents WHERE id = 'doc-001'`).Scan(&dbPath1)
+	db.QueryRow(`SELECT path FROM vault_documents WHERE id = 'doc-002'`).Scan(&dbPath2)
+	if dbPath1 == dbPath2 {
+		t.Fatalf("both rows resolved to the same path %q -- collision", dbPath1)
+	}
+}
+
+// TestMigrateVaultDirIntoMonoagent_MovesDocumentsToo is the regression test
+// for a gap the images-only version of this migration left: vault_documents
+// (uploaded documents, stored under the same old <root>/vault/documents/ as
+// images live in <root>/vault/) was never touched, so the old vault/ dir
+// would never actually go away for a profile with any uploaded documents,
+// and new documents would split across two locations (old for existing
+// rows, new .monoagent/vault/documents/ for anything registered after this
+// change). Both the image and the document must move, and the now-fully-
+// empty old vault/ dir (including its now-empty documents/ subdirectory)
+// must be removed.
+func TestMigrateVaultDirIntoMonoagent_MovesDocumentsToo(t *testing.T) {
+	setHomeForTest(t)
+	db := newVaultTestDB(t)
+
+	root := profiledir.Root(db, "p1")
+	oldDir := filepath.Join(root, "vault")
+	oldDocsDir := filepath.Join(oldDir, "documents")
+	if err := os.MkdirAll(oldDocsDir, 0700); err != nil {
+		t.Fatalf("seed old documents dir: %v", err)
+	}
+
+	imgPath := filepath.Join(oldDir, "img-001.png")
+	os.WriteFile(imgPath, []byte("img"), 0600)
+	db.Exec(`INSERT INTO vault_images (id, path, filename, profile_id) VALUES ('img-001', ?, 'img-001.png', 'p1')`, imgPath)
+
+	docPath := filepath.Join(oldDocsDir, "doc-001.pdf")
+	os.WriteFile(docPath, []byte("doc"), 0600)
+	db.Exec(`INSERT INTO vault_documents (id, path, filename, profile_id, source) VALUES ('doc-001', ?, 'doc-001.pdf', 'p1', 'upload')`, docPath)
+
+	moved, errs := MigrateVaultDirIntoMonoagent(context.Background(), db, "p1")
+	if len(errs) != 0 {
+		t.Fatalf("MigrateVaultDirIntoMonoagent errors: %v", errs)
+	}
+	if moved != 2 {
+		t.Fatalf("moved = %d, want 2 (1 image + 1 document)", moved)
+	}
+
+	newDocPath := filepath.Join(profiledir.VaultDir(db, "p1"), "documents", "doc-001.pdf")
+	if _, err := os.Stat(newDocPath); err != nil {
+		t.Fatalf("document not at new .monoagent/vault/documents path: %v", err)
+	}
+	var dbPath string
+	if err := db.QueryRow(`SELECT path FROM vault_documents WHERE id = 'doc-001'`).Scan(&dbPath); err != nil {
+		t.Fatalf("reading updated document path: %v", err)
+	}
+	if dbPath != newDocPath {
+		t.Fatalf("document db path = %q, want %q", dbPath, newDocPath)
+	}
+	if _, err := os.Stat(oldDir); !os.IsNotExist(err) {
+		t.Fatalf("old vault/ dir should have been fully removed once empty (including documents/), stat err = %v", err)
+	}
+}
+
+// TestMigrateVaultDirIntoMonoagent_LeavesDiscoveredDocumentOutsideVaultUntouched
+// is the safety property the fromDir prefix check exists for: a discovered
+// document's path lives wherever the user's own project put it (e.g. under
+// the docs/ TaxonomyFolder), never inside the vault directory, and this
+// migration must never move or rewrite it -- RegisterDiscoveredDocument
+// never copied that file into monoagent's ownership, and moving it would
+// silently sever the row from the user's real file.
+func TestMigrateVaultDirIntoMonoagent_LeavesDiscoveredDocumentOutsideVaultUntouched(t *testing.T) {
+	setHomeForTest(t)
+	db := newVaultTestDB(t)
+
+	root := profiledir.Root(db, "p1")
+	docsFolder := filepath.Join(root, "docs")
+	if err := os.MkdirAll(docsFolder, 0700); err != nil {
+		t.Fatalf("seed docs folder: %v", err)
+	}
+	discoveredPath := filepath.Join(docsFolder, "notes.md")
+	if err := os.WriteFile(discoveredPath, []byte("user's own notes"), 0600); err != nil {
+		t.Fatalf("seed discovered file: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO vault_documents (id, path, filename, profile_id, source) VALUES ('doc-002', ?, 'notes.md', 'p1', 'discovered')`, discoveredPath); err != nil {
+		t.Fatalf("seed row: %v", err)
+	}
+
+	moved, errs := MigrateVaultDirIntoMonoagent(context.Background(), db, "p1")
+	if len(errs) != 0 || moved != 0 {
+		t.Fatalf("moved=%d errs=%v, want moved=0 no errs (nothing under the old vault dir)", moved, errs)
+	}
+
+	if _, err := os.Stat(discoveredPath); err != nil {
+		t.Fatalf("discovered file must be left in place: %v", err)
+	}
+	var dbPath string
+	if err := db.QueryRow(`SELECT path FROM vault_documents WHERE id = 'doc-002'`).Scan(&dbPath); err != nil {
+		t.Fatalf("reading path: %v", err)
+	}
+	if dbPath != discoveredPath {
+		t.Fatalf("discovered document's db path must be untouched: got %q, want %q", dbPath, discoveredPath)
 	}
 }

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -211,6 +211,105 @@ func MigrateVaultFiles(ctx context.Context, db *sql.DB, profileID string) (moved
 	return MoveFiles(ctx, db, profileID, legacyVaultDir(), VaultDir(db, profileID))
 }
 
+// MigrateVaultDirIntoMonoagent moves one profile's files out of the old
+// per-profile <root>/vault/ folder (visible, unnamespaced, and mixed in
+// with the user's own files whenever root_dir points at a real coding
+// project) into <root>/.monoagent/vault/ — VaultDir's current shape —
+// updating each vault_images/vault_documents row's stored path to match.
+// Both tables are migrated: a profile with uploaded documents has files
+// under the old vault/documents/ too, and leaving those behind would both
+// keep the old vault/ directory around forever (never empty enough to
+// remove) and permanently split documents across the old and new
+// locations. Idempotent, via the same MoveFiles/MoveDocumentFiles used
+// elsewhere: rows no longer under the old dir (already migrated, or a
+// brand new profile that never had one) are left untouched — this
+// includes a "discovered" document, whose path was never inside the vault
+// to begin with (see MoveDocumentFiles). Once the old directory (and its
+// documents/ subdirectory) is empty, both are removed; os.Remove only
+// succeeds on an empty directory, so any file neither move knew about
+// (never registered in either table) is left in place rather than
+// silently discarded.
+func MigrateVaultDirIntoMonoagent(ctx context.Context, db *sql.DB, profileID string) (moved int, errs []error) {
+	root := profiledir.Root(db, profileID)
+	if root == "" {
+		return 0, nil
+	}
+	oldDir := filepath.Join(root, "vault")
+	newVaultDir := VaultDir(db, profileID)
+
+	imgMoved, imgErrs := MoveFiles(ctx, db, profileID, oldDir, newVaultDir)
+	docMoved, docErrs := MoveDocumentFiles(ctx, db, profileID, oldDir, filepath.Join(newVaultDir, "documents"))
+	moved = imgMoved + docMoved
+	errs = append(imgErrs, docErrs...)
+
+	_ = os.Remove(filepath.Join(oldDir, "documents"))
+	_ = os.Remove(oldDir)
+	return moved, errs
+}
+
+// moveTrackedFiles is the shared engine behind MoveFiles and
+// MoveDocumentFiles: given a table with (id, path, profile_id) columns, it
+// moves every profileID-scoped row whose path still lives under fromDir
+// into toDir, renaming the file on disk and updating its stored path to
+// match. Rows whose path lies elsewhere (already moved, or never lived in
+// fromDir) are left completely untouched — the fromDir prefix check is the
+// actual safety boundary, not any assumption about what a row's source is.
+// table is always a caller-supplied literal ("vault_images" or
+// "vault_documents"), never external input, so building the query around
+// it carries no injection risk.
+//
+// The destination filename is always derived from the CURRENT path's own
+// basename, never from a separate `filename` column: vault_images keeps
+// those in sync (Register stores the same id-based name in both), but
+// vault_documents does not — RegisterDocument stores the user's ORIGINAL
+// uploaded name in `filename` while `path` uses a unique id-based name.
+// Two uploads named identically by the user then share a `filename` but
+// have distinct paths; building destPath from `filename` would collide
+// them onto the same destination and os.Rename would silently clobber one
+// with the other. Basenames of the current path are always already unique
+// on disk, so this can't happen.
+func moveTrackedFiles(ctx context.Context, db *sql.DB, table, profileID, fromDir, toDir string) (moved int, errs []error) {
+	if err := os.MkdirAll(toDir, 0700); err != nil {
+		return 0, []error{fmt.Errorf("vault.moveTrackedFiles(%s): ensure dest dir: %w", table, err)}
+	}
+
+	rows, err := db.QueryContext(ctx,
+		fmt.Sprintf(`SELECT id, path FROM %s WHERE COALESCE(profile_id,'default') = ?`, table), profileID)
+	if err != nil {
+		return 0, []error{fmt.Errorf("vault.moveTrackedFiles(%s): query rows: %w", table, err)}
+	}
+	type row struct{ id, path string }
+	var toMove []row
+	for rows.Next() {
+		var r row
+		if err := rows.Scan(&r.id, &r.path); err == nil {
+			toMove = append(toMove, r)
+		}
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		errs = append(errs, fmt.Errorf("vault.moveTrackedFiles(%s): iterate rows: %w", table, err))
+	}
+
+	updateSQL := fmt.Sprintf(`UPDATE %s SET path = ? WHERE id = ?`, table)
+	for _, r := range toMove {
+		if !strings.HasPrefix(r.path, fromDir+string(os.PathSeparator)) {
+			continue // already moved, or never lived in fromDir
+		}
+		destPath := filepath.Join(toDir, filepath.Base(r.path))
+		if err := os.Rename(r.path, destPath); err != nil {
+			errs = append(errs, fmt.Errorf("vault.moveTrackedFiles(%s): move %s: %w", table, r.id, err))
+			continue
+		}
+		if _, err := db.ExecContext(ctx, updateSQL, destPath, r.id); err != nil {
+			errs = append(errs, fmt.Errorf("vault.moveTrackedFiles(%s): update path for %s: %w", table, r.id, err))
+			continue
+		}
+		moved++
+	}
+	return moved, errs
+}
+
 // MoveFiles moves a profile's vault_images files from fromDir to toDir,
 // updating each row's stored path to match. Idempotent: rows whose path
 // isn't inside fromDir (already moved, or never lived there) are left
@@ -218,44 +317,22 @@ func MigrateVaultFiles(ctx context.Context, db *sql.DB, profileID string) (moved
 // didn't move yet. A failure on one row is reported via the returned
 // per-row error list rather than aborting the rest.
 func MoveFiles(ctx context.Context, db *sql.DB, profileID, fromDir, toDir string) (moved int, errs []error) {
-	if err := os.MkdirAll(toDir, 0700); err != nil {
-		return 0, []error{fmt.Errorf("vault.MoveFiles: ensure dest dir: %w", err)}
-	}
+	return moveTrackedFiles(ctx, db, "vault_images", profileID, fromDir, toDir)
+}
 
-	rows, err := db.QueryContext(ctx,
-		`SELECT id, path, filename FROM vault_images WHERE COALESCE(profile_id,'default') = ?`, profileID)
-	if err != nil {
-		return 0, []error{fmt.Errorf("vault.MoveFiles: query rows: %w", err)}
-	}
-	type row struct{ id, path, filename string }
-	var toMove []row
-	for rows.Next() {
-		var r row
-		if err := rows.Scan(&r.id, &r.path, &r.filename); err == nil {
-			toMove = append(toMove, r)
-		}
-	}
-	rows.Close()
-	if err := rows.Err(); err != nil {
-		errs = append(errs, fmt.Errorf("vault.MoveFiles: iterate rows: %w", err))
-	}
-
-	for _, r := range toMove {
-		if !strings.HasPrefix(r.path, fromDir+string(os.PathSeparator)) {
-			continue // already moved, or never lived in fromDir
-		}
-		destPath := filepath.Join(toDir, r.filename)
-		if err := os.Rename(r.path, destPath); err != nil {
-			errs = append(errs, fmt.Errorf("vault.MoveFiles: move %s: %w", r.id, err))
-			continue
-		}
-		if _, err := db.ExecContext(ctx, `UPDATE vault_images SET path = ? WHERE id = ?`, destPath, r.id); err != nil {
-			errs = append(errs, fmt.Errorf("vault.MoveFiles: update path for %s: %w", r.id, err))
-			continue
-		}
-		moved++
-	}
-	return moved, errs
+// MoveDocumentFiles is MoveFiles' counterpart for vault_documents. It has
+// to exist separately (rather than everyone just calling MoveFiles twice)
+// because vault_documents mixes two very differently-owned kinds of rows:
+// files RegisterDocument copied into the vault (source "upload" etc.),
+// which belong under fromDir/toDir exactly like images, and files
+// RegisterDiscoveredDocument recorded in place (source "discovered")
+// that live wherever the user's own project put them and were never
+// copied anywhere. moveTrackedFiles's fromDir prefix check is what keeps
+// this safe regardless: a discovered document's path is essentially never
+// under the vault directory, so it is simply skipped — never moved,
+// never rewritten.
+func MoveDocumentFiles(ctx context.Context, db *sql.DB, profileID, fromDir, toDir string) (moved int, errs []error) {
+	return moveTrackedFiles(ctx, db, "vault_documents", profileID, fromDir, toDir)
 }
 
 // Resolve turns "@img-001" into the absolute file path stored in the DB.

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -71,6 +71,9 @@ func newVaultTestDB(t *testing.T) *sql.DB {
 	if _, err := db.Exec(`CREATE TABLE vault_images (id TEXT PRIMARY KEY, path TEXT, filename TEXT, profile_id TEXT DEFAULT 'default')`); err != nil {
 		t.Fatalf("create table: %v", err)
 	}
+	if _, err := db.Exec(`CREATE TABLE vault_documents (id TEXT PRIMARY KEY, path TEXT, filename TEXT, profile_id TEXT DEFAULT 'default', source TEXT DEFAULT 'upload')`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
 	return db
 }
 

--- a/wails-app/app.go
+++ b/wails-app/app.go
@@ -210,14 +210,18 @@ func (a *App) IsReady() bool {
 
 // migrateProfilesToPerProfileLayout brings every existing profile up to the
 // per-profile architecture: a dedicated folder, its files moved out of the
-// old shared vault directory, its secrets re-encrypted under its own key
-// (instead of the one every profile used to share), and an empty monomind
-// project bootstrapped for its knowledge graph. Runs once per app startup,
-// for every profile — each underlying step is already cheap and idempotent
-// once a profile is fully migrated (a handful of COUNT-first queries), the
-// same "run it every startup, no-op once done" pattern the migrations right
-// above this call already use (MigrateConnectionsToVault et al.). A failure
-// on one profile is logged and does not block the others or app startup.
+// old shared vault directory and then out of that per-profile folder's own
+// legacy vault/ into .monoagent/vault/ (so everything monoagent owns is a
+// single unit, distinct from .monomind/ and the user-visible taxonomy
+// folders), its secrets re-encrypted under its own key (instead of the one
+// every profile used to share), and an empty monomind project bootstrapped
+// for its knowledge graph. Runs once per app startup, for every profile —
+// each underlying step is already cheap and idempotent once a profile is
+// fully migrated (a handful of COUNT-first queries or a no-op MoveFiles),
+// the same "run it every startup, no-op once done" pattern the migrations
+// right above this call already use (MigrateConnectionsToVault et al.). A
+// failure on one profile is logged and does not block the others or app
+// startup.
 func (a *App) migrateProfilesToPerProfileLayout(ctx context.Context, db *sql.DB) {
 	rows, err := db.QueryContext(ctx, `SELECT id FROM profiles`)
 	if err != nil {
@@ -245,6 +249,15 @@ func (a *App) migrateProfilesToPerProfileLayout(ctx context.Context, db *sql.DB)
 			}
 			if moved > 0 {
 				a.emitLog("SYSTEM", "INFO", fmt.Sprintf("profile %s: moved %d vault file(s) into its own folder", profileID, moved))
+			}
+		}
+
+		if moved, errs := vault.MigrateVaultDirIntoMonoagent(ctx, db, profileID); moved > 0 || len(errs) > 0 {
+			for _, e := range errs {
+				a.emitLog("SYSTEM", "WARN", fmt.Sprintf("profile %s: .monoagent vault migration: %v", profileID, e))
+			}
+			if moved > 0 {
+				a.emitLog("SYSTEM", "INFO", fmt.Sprintf("profile %s: moved %d vault file(s) into its own .monoagent folder", profileID, moved))
 			}
 		}
 
@@ -931,13 +944,17 @@ type ProfileInfo struct {
 	// always populated (even for profiles using the default location), so
 	// the frontend never needs to know the fallback rule itself.
 	RootDir string `json:"root_dir"`
+	// Icon is an id into the shared agent-avatars.json manifest (the same
+	// one Org Designer role icons use), or "" if none was chosen — profiles
+	// created before this field existed are always "".
+	Icon string `json:"icon"`
 }
 
 func (a *App) GetProfiles() ([]ProfileInfo, error) {
 	if a.db == nil {
 		return nil, fmt.Errorf("database not available")
 	}
-	rows, err := a.db.Query(`SELECT id, name, created_at FROM profiles ORDER BY created_at ASC`)
+	rows, err := a.db.Query(`SELECT id, name, created_at, icon FROM profiles ORDER BY created_at ASC`)
 	if err != nil {
 		return nil, err
 	}
@@ -945,7 +962,7 @@ func (a *App) GetProfiles() ([]ProfileInfo, error) {
 	var profiles []ProfileInfo
 	for rows.Next() {
 		var p ProfileInfo
-		if rows.Scan(&p.ID, &p.Name, &p.CreatedAt) == nil {
+		if rows.Scan(&p.ID, &p.Name, &p.CreatedAt, &p.Icon) == nil {
 			p.IsActive = p.ID == a.getActiveProfileID()
 			p.RootDir = profiledir.Root(a.db, p.ID)
 			profiles = append(profiles, p)
@@ -958,13 +975,16 @@ func (a *App) GetProfiles() ([]ProfileInfo, error) {
 }
 
 // CreateProfile creates a new profile. rootDir, if non-empty, is the folder
-// the user picked (via ChooseProfileFolder) for this profile's data instead
-// of the default ~/.monoagent/profiles/<id>/ — it must be an absolute path;
-// see validateFolderChoice for what else is required of it (an existing
-// folder need not be empty — e.g. an existing coding project you already run
+// the user picked (via ChooseProfileFolder, or a suggested monomind project
+// via ListMonomindProjects) for this profile's data instead of the default
+// ~/.monoagent/profiles/<id>/ — it must be an absolute path; see
+// validateFolderChoice for what else is required of it (an existing folder
+// need not be empty — e.g. an existing coding project you already run
 // monomind/Claude Code in is a perfectly good choice — but it must be safe
-// to layer this profile's vault/ and .monomind/ subfolders onto).
-func (a *App) CreateProfile(name, rootDir string) (*ProfileInfo, error) {
+// to layer this profile's .monoagent/ and .monomind/ subfolders onto). icon,
+// if non-empty, is an id into the shared agent-avatars.json manifest;
+// leaving it empty is fine, the frontend falls back to a placeholder.
+func (a *App) CreateProfile(name, rootDir, icon string) (*ProfileInfo, error) {
 	if a.db == nil {
 		return nil, fmt.Errorf("database not available")
 	}
@@ -978,9 +998,10 @@ func (a *App) CreateProfile(name, rootDir string) (*ProfileInfo, error) {
 			return nil, err
 		}
 	}
+	icon = strings.TrimSpace(icon)
 	id := newUUID()
 	now := time.Now().UTC().Format("2006-01-02T15:04:05Z")
-	_, err := a.db.Exec(`INSERT INTO profiles (id, name, created_at, root_dir) VALUES (?, ?, ?, ?)`, id, name, now, rootDir)
+	_, err := a.db.Exec(`INSERT INTO profiles (id, name, created_at, root_dir, icon) VALUES (?, ?, ?, ?, ?)`, id, name, now, rootDir, icon)
 	if err != nil {
 		return nil, fmt.Errorf("create profile: %w", err)
 	}
@@ -992,19 +1013,19 @@ func (a *App) CreateProfile(name, rootDir string) (*ProfileInfo, error) {
 	} else {
 		a.bootstrapProfileMonograph(id)
 	}
-	return &ProfileInfo{ID: id, Name: name, IsActive: false, CreatedAt: now, RootDir: profiledir.Root(a.db, id)}, nil
+	return &ProfileInfo{ID: id, Name: name, IsActive: false, CreatedAt: now, RootDir: profiledir.Root(a.db, id), Icon: icon}, nil
 }
 
 // validateFolderChoice rejects a folder choice that isn't safe to hand a
 // profile's data to. The folder need not be empty or new — pointing a
 // profile at an existing, non-empty folder (e.g. a coding project that
 // already has its own .monomind/ from a prior `monomind init`) is fine:
-// EnsureLayout only ever adds a vault/ and a .monomind/ subfolder inside it
-// and never touches anything else there, so nothing pre-existing is at risk
-// except those two specific names. What's actually unsafe, and rejected
-// here, is a `vault` or `.monomind` entry that already exists as a plain
-// file rather than a directory — os.MkdirAll would fail confusingly on
-// that, so it's caught up front with a clear message instead.
+// EnsureLayout only ever adds a .monoagent/ and a .monomind/ subfolder
+// inside it and never touches anything else there, so nothing pre-existing
+// is at risk except those two specific names. What's actually unsafe, and
+// rejected here, is a `.monoagent` or `.monomind` entry that already exists
+// as a plain file rather than a directory — os.MkdirAll would fail
+// confusingly on that, so it's caught up front with a clear message instead.
 func validateFolderChoice(dir string) error {
 	if !filepath.IsAbs(dir) {
 		return fmt.Errorf("folder path must be absolute: %q", dir)
@@ -1019,7 +1040,7 @@ func validateFolderChoice(dir string) error {
 	if !info.IsDir() {
 		return fmt.Errorf("%q is not a folder", dir)
 	}
-	for _, name := range []string{"vault", ".monomind"} {
+	for _, name := range []string{".monoagent", ".monomind"} {
 		entryInfo, err := os.Stat(filepath.Join(dir, name))
 		if err != nil {
 			continue // doesn't exist — fine, EnsureLayout creates it
@@ -1145,7 +1166,7 @@ func (a *App) MoveProfileFolder(profileID, newRootDir string) error {
 
 	oldVaultDir := profiledir.VaultDir(a.db, profileID)
 	oldMonomindDir := profiledir.MonomindDir(a.db, profileID)
-	newVaultDir := filepath.Join(newRootDir, "vault")
+	newVaultDir := filepath.Join(newRootDir, ".monoagent", "vault")
 	newMonomindDir := filepath.Join(newRootDir, ".monomind")
 
 	if err := os.MkdirAll(newVaultDir, 0700); err != nil {

--- a/wails-app/app_monomind_projects.go
+++ b/wails-app/app_monomind_projects.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// MonomindProjectInfo is one suggestion in the New Profile modal's "pick an
+// existing monomind project" list.
+type MonomindProjectInfo struct {
+	Path string `json:"path"`
+	Name string `json:"name"`
+}
+
+// monomindProjectsFile is the shape of ~/.monomind-projects.json, written by
+// monomind's own `init upgrade --all` (see registerClaudeCodeProject's doc
+// comment in app_monomind_init.go for the sibling ~/.claude/projects/ list
+// this is distinct from). Not owned by monoagent — read-only here.
+type monomindProjectsFile struct {
+	Projects []string `json:"projects"`
+}
+
+// readMonomindProjectsFile returns the raw project path list, or nil if the
+// file doesn't exist or can't be parsed — this is a convenience suggestion,
+// never worth failing the New Profile modal over.
+func readMonomindProjectsFile() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = os.Getenv("HOME")
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".monomind-projects.json"))
+	if err != nil {
+		return nil
+	}
+	var f monomindProjectsFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		return nil
+	}
+	return f.Projects
+}
+
+// filterMonomindProjects turns a raw path list (as noisy as monomind's own
+// init-upgrade bookkeeping — temp test directories from monomind's own test
+// suite, one-off /tmp paths, monoagent's own profile folders — routinely
+// makes it) into a small, meaningful suggestion list:
+//   - a path that no longer exists, or was never (or is no longer) a real
+//     monomind project (checked the same way IsMonomindInitialized does —
+//     .monomind/config.yaml), is dropped — this one check alone eliminates
+//     essentially all the ephemeral test-run noise
+//   - a path already used as an existing profile's root_dir is dropped —
+//     no point suggesting a project that already has one
+//   - exact-duplicate paths collapse to their first occurrence
+//
+// Preserves the input's order — the source file carries no recency signal
+// worth inventing one for.
+func filterMonomindProjects(rawPaths []string, existingRootDirs map[string]bool) []MonomindProjectInfo {
+	seen := make(map[string]bool, len(rawPaths))
+	out := []MonomindProjectInfo{}
+	for _, p := range rawPaths {
+		if seen[p] {
+			continue
+		}
+		seen[p] = true
+		if existingRootDirs[p] {
+			continue
+		}
+		if !isMonomindInitializedAt(p) {
+			continue
+		}
+		out = append(out, MonomindProjectInfo{Path: p, Name: filepath.Base(p)})
+	}
+	return out
+}
+
+// ListMonomindProjects suggests existing monomind projects for the New
+// Profile modal to offer — picking one fills both the profile's name and
+// its root directory. Never errors: an empty result just means the modal
+// shows no suggestions.
+func (a *App) ListMonomindProjects() []MonomindProjectInfo {
+	raw := readMonomindProjectsFile()
+	if len(raw) == 0 {
+		return []MonomindProjectInfo{}
+	}
+
+	existingRootDirs := map[string]bool{}
+	if a.db != nil {
+		rows, err := a.db.Query(`SELECT root_dir FROM profiles WHERE root_dir != ''`)
+		if err == nil {
+			defer rows.Close()
+			for rows.Next() {
+				var rd string
+				if rows.Scan(&rd) == nil {
+					existingRootDirs[rd] = true
+				}
+			}
+		}
+	}
+
+	return filterMonomindProjects(raw, existingRootDirs)
+}

--- a/wails-app/app_monomind_projects_test.go
+++ b/wails-app/app_monomind_projects_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// makeMonomindProject creates dir/.monomind/config.yaml so
+// isMonomindInitializedAt(dir) reports true — the same on-disk marker
+// monomind's own CLI uses.
+func makeMonomindProject(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".monomind"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".monomind", "config.yaml"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestFilterMonomindProjects covers the suggestion-list filtering rules:
+// the real ~/.monomind-projects.json on a real machine is very noisy (temp
+// test dirs from monomind's own test suite, one-off /tmp paths, monoagent's
+// own profile folders) — filterMonomindProjects is what turns that into a
+// small, meaningful suggestion list.
+func TestFilterMonomindProjects(t *testing.T) {
+	base := t.TempDir()
+
+	realProject := filepath.Join(base, "real-project")
+	makeMonomindProject(t, realProject)
+
+	alreadyAProfile := filepath.Join(base, "already-a-profile")
+	makeMonomindProject(t, alreadyAProfile)
+
+	neverInitialized := filepath.Join(base, "never-initialized")
+	if err := os.MkdirAll(neverInitialized, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	deletedProject := filepath.Join(base, "deleted-project") // never created on disk
+
+	t.Run("keeps only paths that exist and are currently monomind-initialized", func(t *testing.T) {
+		got := filterMonomindProjects(
+			[]string{realProject, neverInitialized, deletedProject},
+			map[string]bool{},
+		)
+		if len(got) != 1 {
+			t.Fatalf("got %d projects, want 1: %+v", len(got), got)
+		}
+		if got[0].Path != realProject || got[0].Name != "real-project" {
+			t.Fatalf("got %+v, want Path=%q Name=%q", got[0], realProject, "real-project")
+		}
+	})
+
+	t.Run("excludes a path already used as a profile's root_dir", func(t *testing.T) {
+		got := filterMonomindProjects(
+			[]string{realProject, alreadyAProfile},
+			map[string]bool{alreadyAProfile: true},
+		)
+		if len(got) != 1 || got[0].Path != realProject {
+			t.Fatalf("got %+v, want only %q", got, realProject)
+		}
+	})
+
+	t.Run("dedupes exact-duplicate paths, keeping the first occurrence's order", func(t *testing.T) {
+		second := filepath.Join(base, "second-project")
+		makeMonomindProject(t, second)
+
+		got := filterMonomindProjects(
+			[]string{realProject, second, realProject},
+			map[string]bool{},
+		)
+		if len(got) != 2 {
+			t.Fatalf("got %d projects, want 2 (deduped): %+v", len(got), got)
+		}
+		if got[0].Path != realProject || got[1].Path != second {
+			t.Fatalf("got order %+v, want [%q, %q]", got, realProject, second)
+		}
+	})
+
+	t.Run("empty input yields an empty (non-nil-relevant) slice", func(t *testing.T) {
+		got := filterMonomindProjects(nil, map[string]bool{})
+		if len(got) != 0 {
+			t.Fatalf("got %d projects, want 0", len(got))
+		}
+	})
+}

--- a/wails-app/app_test.go
+++ b/wails-app/app_test.go
@@ -41,7 +41,7 @@ func TestRevealFolderCommand(t *testing.T) {
 // letting CreateProfile/MoveProfileFolder point a profile at an existing,
 // non-empty folder (e.g. a coding project already initialized with
 // `monomind init`) instead of requiring an empty one — EnsureLayout only
-// ever adds vault/ and .monomind/ alongside whatever is already there.
+// ever adds .monoagent/ and .monomind/ alongside whatever is already there.
 func TestValidateFolderChoiceAllowsNonEmptyFolders(t *testing.T) {
 	t.Run("relative path rejected", func(t *testing.T) {
 		if err := validateFolderChoice("relative/path"); err == nil {
@@ -100,13 +100,13 @@ func TestValidateFolderChoiceAllowsNonEmptyFolders(t *testing.T) {
 		}
 	})
 
-	t.Run("a plain file named vault is rejected", func(t *testing.T) {
+	t.Run("a plain file named .monoagent is rejected", func(t *testing.T) {
 		dir := t.TempDir()
-		if err := os.WriteFile(filepath.Join(dir, "vault"), []byte("x"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, ".monoagent"), []byte("x"), 0644); err != nil {
 			t.Fatal(err)
 		}
 		if err := validateFolderChoice(dir); err == nil {
-			t.Fatal("expected an error when \"vault\" already exists as a file, got nil")
+			t.Fatal("expected an error when \".monoagent\" already exists as a file, got nil")
 		}
 	})
 

--- a/wails-app/frontend/src/components/NewProfileModal.jsx
+++ b/wails-app/frontend/src/components/NewProfileModal.jsx
@@ -1,0 +1,189 @@
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { FolderOpen } from 'lucide-react'
+import * as WailsApp from '../wailsjs/go/main/App'
+import { iconUrl } from './orgdesigner/roleIcons.js'
+import IconPickerModal from './orgdesigner/IconPickerModal.jsx'
+
+const CreateProfile = WailsApp.CreateProfile ?? (async () => {})
+const ChooseProfileFolder = WailsApp.ChooseProfileFolder ?? (async () => '')
+const ListMonomindProjects = WailsApp.ListMonomindProjects ?? (async () => [])
+
+/**
+ * NewProfileModal — centered replacement for the old inline "+ New profile"
+ * expand-in-place row. Adds two things the inline form never had: an icon
+ * picker (delegating to the shared IconPickerModal, the same one Org
+ * Designer roles use — no second picker built for this) and a list of the
+ * user's existing monomind projects to pick from; picking one sets both the
+ * Name field and the folder this profile's data will live in (root_dir),
+ * exactly like manually typing a name and choosing a folder would.
+ *
+ * @param {boolean} open
+ * @param {() => void} onClose
+ * @param {(profile: object) => void} onCreated Called with the created
+ *   ProfileInfo once CreateProfile succeeds, right before onClose.
+ */
+export default function NewProfileModal({ open, onClose, onCreated }) {
+  const { t } = useTranslation()
+  const [name, setName] = useState('')
+  const [rootDir, setRootDir] = useState('')
+  const [icon, setIcon] = useState('')
+  const [iconPickerOpen, setIconPickerOpen] = useState(false)
+  const [projects, setProjects] = useState([])
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState('')
+  const nameRef = useRef(null)
+
+  useEffect(() => {
+    if (!open) return
+    setName('')
+    setRootDir('')
+    setIcon('')
+    setError('')
+    setBusy(false)
+    ListMonomindProjects().then(list => setProjects(Array.isArray(list) ? list : [])).catch(() => setProjects([]))
+    setTimeout(() => nameRef.current?.focus(), 30)
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e) => { if (e.key === 'Escape' && !iconPickerOpen) onClose?.() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, iconPickerOpen, onClose])
+
+  if (!open) return null
+
+  const pickProject = (project) => {
+    setName(project.name)
+    setRootDir(project.path)
+  }
+
+  const chooseOtherFolder = async () => {
+    try {
+      const path = await ChooseProfileFolder()
+      if (path) setRootDir(path)
+    } catch (e) {
+      setError(e?.message || 'Failed to choose folder')
+    }
+  }
+
+  const handleCreate = async () => {
+    const trimmed = name.trim()
+    if (!trimmed || busy) return
+    setBusy(true)
+    setError('')
+    try {
+      const profile = await CreateProfile(trimmed, rootDir, icon)
+      onCreated?.(profile)
+      onClose?.()
+    } catch (e) {
+      setError(e?.message || 'Failed to create profile')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <>
+      <div className="modal-overlay" onClick={e => { if (e.target === e.currentTarget) onClose?.() }}>
+        <div role="dialog" aria-modal="true" aria-label={t('newProfileModal.title')} className="modal" style={{ width: 460 }}>
+          <div className="modal-title">{t('newProfileModal.title')}</div>
+
+          <div style={{ display: 'flex', gap: 10, marginBottom: 14 }}>
+            <button
+              onClick={() => setIconPickerOpen(true)}
+              title={t('newProfileModal.chooseIcon')}
+              style={{
+                padding: 0, border: '2px solid rgba(0,180,216,0.3)', borderRadius: '50%',
+                cursor: 'pointer', background: 'transparent', flexShrink: 0, width: 44, height: 44,
+              }}
+            >
+              <img src={iconUrl(icon || 'coder')} alt="" style={{ width: '100%', height: '100%', borderRadius: '50%', display: 'block' }} />
+            </button>
+            <input
+              ref={nameRef}
+              className="form-input"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter') handleCreate() }}
+              placeholder={t('newProfileModal.namePlaceholder')}
+              style={{ flex: 1 }}
+            />
+          </div>
+
+          {projects.length > 0 && (
+            <div style={{ marginBottom: 14 }}>
+              <div className="form-label">{t('newProfileModal.suggestedProjects')}</div>
+              <div style={{ maxHeight: 160, overflowY: 'auto', border: '1px solid var(--border-dim)', borderRadius: 6 }}>
+                {projects.map(p => (
+                  <div
+                    key={p.path}
+                    onClick={() => pickProject(p)}
+                    style={{
+                      padding: '7px 10px', cursor: 'pointer',
+                      background: rootDir === p.path ? 'rgba(0,180,216,0.1)' : 'transparent',
+                      borderBottom: '1px solid var(--border-dim)',
+                    }}
+                    onMouseEnter={e => { if (rootDir !== p.path) e.currentTarget.style.background = 'rgba(255,255,255,0.04)' }}
+                    onMouseLeave={e => { if (rootDir !== p.path) e.currentTarget.style.background = 'transparent' }}
+                  >
+                    <div style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--text)' }}>{p.name}</div>
+                    <div
+                      title={p.path}
+                      style={{
+                        fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--text-muted)',
+                        overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                      }}
+                    >{p.path}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div style={{ marginBottom: 14 }}>
+            <button
+              onClick={chooseOtherFolder}
+              className="btn btn-secondary btn-sm"
+              style={{ display: 'flex', alignItems: 'center', gap: 6 }}
+            >
+              <FolderOpen size={12} /> {t('newProfileModal.chooseDifferentFolder')}
+            </button>
+            {rootDir && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 6 }}>
+                <span style={{
+                  flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap', fontFamily: 'var(--font-mono)', fontSize: 10.5, color: 'var(--text-muted)',
+                }}>→ {rootDir}</span>
+                <span
+                  onClick={() => setRootDir('')}
+                  title={t('newProfileModal.useDefaultLocation')}
+                  style={{ flexShrink: 0, fontSize: 12, color: 'var(--text-muted)', cursor: 'pointer' }}
+                >×</span>
+              </div>
+            )}
+          </div>
+
+          {error && (
+            <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: '#ff6b6b', marginBottom: 10 }}>{error}</div>
+          )}
+
+          <div className="modal-actions">
+            <button className="btn btn-ghost" onClick={onClose}>{t('newProfileModal.cancel')}</button>
+            <button className="btn btn-primary" onClick={handleCreate} disabled={busy || !name.trim()}>
+              {busy ? t('newProfileModal.creating') : t('newProfileModal.create')}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <IconPickerModal
+        open={iconPickerOpen}
+        currentIconId={icon}
+        onSelect={setIcon}
+        onClose={() => setIconPickerOpen(false)}
+      />
+    </>
+  )
+}

--- a/wails-app/frontend/src/components/NewProfileModal.render.test.jsx
+++ b/wails-app/frontend/src/components/NewProfileModal.render.test.jsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import NewProfileModal from './NewProfileModal.jsx'
+
+const mockCreateProfile = vi.fn()
+const mockChooseProfileFolder = vi.fn()
+const mockListMonomindProjects = vi.fn()
+
+vi.mock('../wailsjs/go/main/App', () => ({
+  CreateProfile: (...args) => mockCreateProfile(...args),
+  ChooseProfileFolder: (...args) => mockChooseProfileFolder(...args),
+  ListMonomindProjects: (...args) => mockListMonomindProjects(...args),
+}))
+
+// Matches Sidebar.render.test.jsx's convention: assert against the raw
+// translation key rather than bootstrapping real i18next in a unit test.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key }),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // jsdom doesn't implement scrollIntoView; IconPickerModal calls it in an
+  // effect whenever its focused tile changes, which crashes the whole tree
+  // in a jsdom test environment otherwise (real browsers have it).
+  Element.prototype.scrollIntoView = vi.fn()
+  mockListMonomindProjects.mockResolvedValue([])
+  mockCreateProfile.mockResolvedValue({ id: 'new-id', name: 'x' })
+  global.fetch = vi.fn(() =>
+    Promise.resolve({
+      json: () => Promise.resolve({
+        agents: [
+          { id: 'coder', label: 'Coder', category: 'Tech' },
+          { id: 'writer', label: 'Writer', category: 'Content' },
+        ],
+      }),
+    }),
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  delete global.fetch
+})
+
+it('renders nothing when closed', () => {
+  const { container } = render(<NewProfileModal open={false} onClose={() => {}} onCreated={() => {}} />)
+  expect(container).toBeEmptyDOMElement()
+})
+
+it('renders a centered dialog with a name field when open', async () => {
+  render(<NewProfileModal open={true} onClose={() => {}} onCreated={() => {}} />)
+  expect(screen.getByRole('dialog', { name: 'newProfileModal.title' })).toBeInTheDocument()
+  expect(screen.getByPlaceholderText('newProfileModal.namePlaceholder')).toBeInTheDocument()
+  await waitFor(() => expect(mockListMonomindProjects).toHaveBeenCalled())
+})
+
+it('creates a profile with the typed name and no folder/icon by default', async () => {
+  const onCreated = vi.fn()
+  const onClose = vi.fn()
+  render(<NewProfileModal open={true} onClose={onClose} onCreated={onCreated} />)
+
+  fireEvent.change(screen.getByPlaceholderText('newProfileModal.namePlaceholder'), { target: { value: 'Election Campaign' } })
+  fireEvent.click(screen.getByText('newProfileModal.create'))
+
+  await waitFor(() => expect(mockCreateProfile).toHaveBeenCalledWith('Election Campaign', '', ''))
+  await waitFor(() => expect(onCreated).toHaveBeenCalled())
+  expect(onClose).toHaveBeenCalled()
+})
+
+it('lists suggested monomind projects and picking one fills name and folder', async () => {
+  mockListMonomindProjects.mockResolvedValue([
+    { path: '/Users/morteza/Desktop/monoes/monomind', name: 'monomind' },
+  ])
+  render(<NewProfileModal open={true} onClose={() => {}} onCreated={() => {}} />)
+
+  const projectRow = await screen.findByText('monomind')
+  fireEvent.click(projectRow)
+
+  expect(screen.getByPlaceholderText('newProfileModal.namePlaceholder')).toHaveValue('monomind')
+  expect(screen.getByText('→ /Users/morteza/Desktop/monoes/monomind')).toBeInTheDocument()
+
+  fireEvent.click(screen.getByText('newProfileModal.create'))
+  await waitFor(() =>
+    expect(mockCreateProfile).toHaveBeenCalledWith('monomind', '/Users/morteza/Desktop/monoes/monomind', ''),
+  )
+})
+
+it('does not render any project suggestions when there are none', async () => {
+  render(<NewProfileModal open={true} onClose={() => {}} onCreated={() => {}} />)
+  await waitFor(() => expect(mockListMonomindProjects).toHaveBeenCalled())
+  expect(screen.queryByText('newProfileModal.suggestedProjects')).not.toBeInTheDocument()
+})
+
+it('picking an icon updates the preview and is included in the create call', async () => {
+  render(<NewProfileModal open={true} onClose={() => {}} onCreated={() => {}} />)
+
+  fireEvent.click(screen.getByTitle('newProfileModal.chooseIcon'))
+  const writerTile = await screen.findByTitle('Writer')
+  fireEvent.click(writerTile)
+
+  fireEvent.change(screen.getByPlaceholderText('newProfileModal.namePlaceholder'), { target: { value: 'Content Team' } })
+  fireEvent.click(screen.getByText('newProfileModal.create'))
+
+  await waitFor(() => expect(mockCreateProfile).toHaveBeenCalledWith('Content Team', '', 'writer'))
+})
+
+it('backdrop click and Escape both close the modal', () => {
+  const onClose = vi.fn()
+  const { container } = render(<NewProfileModal open={true} onClose={onClose} onCreated={() => {}} />)
+
+  fireEvent.click(container.querySelector('.modal-overlay'))
+  expect(onClose).toHaveBeenCalledTimes(1)
+
+  fireEvent.keyDown(window, { key: 'Escape' })
+  expect(onClose).toHaveBeenCalledTimes(2)
+})

--- a/wails-app/frontend/src/components/Sidebar.jsx
+++ b/wails-app/frontend/src/components/Sidebar.jsx
@@ -10,10 +10,11 @@ import { GetVersion } from '../wailsjs/go/main/App'
 import * as WailsApp from '../wailsjs/go/main/App'
 import { notify } from '../services/api.js'
 import { confirm } from './ConfirmDialog.jsx'
+import NewProfileModal from './NewProfileModal.jsx'
+import { iconUrl } from './orgdesigner/roleIcons.js'
 
 const GetHILItems          = WailsApp.GetHILItems          ?? (async () => [])
 const GetProfiles          = WailsApp.GetProfiles          ?? (async () => [])
-const CreateProfile        = WailsApp.CreateProfile        ?? (async () => {})
 const SwitchProfile        = WailsApp.SwitchProfile        ?? (async () => {})
 const ChooseProfileFolder  = WailsApp.ChooseProfileFolder  ?? (async () => '')
 const MoveProfileFolder    = WailsApp.MoveProfileFolder    ?? (async () => {})
@@ -58,9 +59,7 @@ export default function Sidebar({ activePage, onNavigate, stats, dbConnected }) 
   const [profiles, setProfiles] = useState([])
   const [activeProfileID, setActiveProfileID] = useState('default')
   const [profileOpen, setProfileOpen] = useState(false)
-  const [newProfileName, setNewProfileName] = useState('')
-  const [newProfileFolder, setNewProfileFolder] = useState('')
-  const [creatingProfile, setCreatingProfile] = useState(false)
+  const [showNewProfileModal, setShowNewProfileModal] = useState(false)
   const [profileError, setProfileError] = useState('')
   const [movingProfileID, setMovingProfileID] = useState(null)
   const [dropPos, setDropPos] = useState({ top: 0, left: 0, width: 0 })
@@ -90,9 +89,6 @@ export default function Sidebar({ activePage, onNavigate, stats, dbConnected }) 
         profileBtnRef.current && !profileBtnRef.current.contains(e.target)
       ) {
         setProfileOpen(false)
-        setCreatingProfile(false)
-        setNewProfileName('')
-        setNewProfileFolder('')
       }
     }
     document.addEventListener('mousedown', handler)
@@ -109,9 +105,6 @@ export default function Sidebar({ activePage, onNavigate, stats, dbConnected }) 
   const toggleProfileOpen = () => {
     if (!profileOpen) updateDropPos()
     setProfileOpen(v => !v)
-    setCreatingProfile(false)
-    setNewProfileName('')
-    setNewProfileFolder('')
     setProfileError('')
   }
 
@@ -135,29 +128,9 @@ export default function Sidebar({ activePage, onNavigate, stats, dbConnected }) 
     }
   }
 
-  const handleCreateProfile = async () => {
-    const name = newProfileName.trim()
-    if (!name) return
-    setProfileError('')
-    try {
-      const p = await CreateProfile(name, newProfileFolder || '')
-      setNewProfileName('')
-      setNewProfileFolder('')
-      setCreatingProfile(false)
-      await loadProfiles()
-      await handleSwitchProfile(p.id)
-    } catch (e) {
-      setProfileError(e?.message || 'Failed to create profile')
-    }
-  }
-
-  const handleChooseFolderForCreate = async () => {
-    try {
-      const path = await ChooseProfileFolder()
-      if (path) setNewProfileFolder(path)
-    } catch (e) {
-      setProfileError(e?.message || 'Failed to choose folder')
-    }
+  const handleProfileCreated = async (profile) => {
+    await loadProfiles()
+    if (profile?.id) await handleSwitchProfile(profile.id)
   }
 
   const handleMoveProfileFolder = async (id) => {
@@ -279,6 +252,13 @@ export default function Sidebar({ activePage, onNavigate, stats, dbConnected }) 
                 onMouseLeave={e => { e.currentTarget.style.background = p.id === activeProfileID ? 'rgba(0,180,216,0.07)' : 'transparent' }}
               >
                 {p.id === activeProfileID ? <Check size={11} color="#00b4d8" /> : <span style={{ width: 11 }} />}
+                {p.icon && (
+                  <img
+                    src={iconUrl(p.icon)}
+                    alt=""
+                    style={{ width: 18, height: 18, borderRadius: '50%', flexShrink: 0 }}
+                  />
+                )}
                 <div style={{ flex: 1, minWidth: 0 }}>
                   <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.name}</div>
                   {p.root_dir && (
@@ -329,73 +309,29 @@ export default function Sidebar({ activePage, onNavigate, stats, dbConnected }) 
               </div>
             )}
             <div style={{ borderTop: '1px solid rgba(255,255,255,0.06)', padding: '8px' }}>
-              {creatingProfile ? (
-                <div>
-                  <div style={{ display: 'flex', gap: 6 }}>
-                    <input
-                      autoFocus
-                      value={newProfileName}
-                      onChange={e => setNewProfileName(e.target.value)}
-                      onKeyDown={e => { if (e.key === 'Enter') handleCreateProfile(); if (e.key === 'Escape') { setCreatingProfile(false); setNewProfileName(''); setNewProfileFolder('') } }}
-                      placeholder={t('sidebar.profileNamePlaceholder')}
-                      style={{
-                        flex: 1, padding: '5px 8px', background: 'rgba(255,255,255,0.06)',
-                        border: '1px solid rgba(0,180,216,0.3)', borderRadius: 4,
-                        color: 'var(--text-primary)', fontSize: 12, outline: 'none',
-                      }}
-                    />
-                    <button
-                      onClick={handleChooseFolderForCreate}
-                      title={t('sidebar.chooseFolder')}
-                      style={{
-                        flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center',
-                        width: 26, padding: '5px 0', background: 'rgba(255,255,255,0.06)',
-                        border: '1px solid rgba(255,255,255,0.12)', borderRadius: 4,
-                        color: 'var(--text-secondary)', cursor: 'pointer',
-                      }}
-                    ><FolderOpen size={12} /></button>
-                    <button
-                      onClick={handleCreateProfile}
-                      style={{
-                        padding: '5px 10px', background: 'rgba(0,180,216,0.2)',
-                        border: '1px solid rgba(0,180,216,0.4)', borderRadius: 4,
-                        color: '#00b4d8', fontSize: 12, cursor: 'pointer',
-                      }}
-                    >Create</button>
-                  </div>
-                  {newProfileFolder && (
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 4, padding: '0 2px' }}>
-                      <span style={{
-                        flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap', fontSize: 10, color: 'var(--text-muted)',
-                      }}>→ {newProfileFolder}</span>
-                      <span
-                        onClick={() => setNewProfileFolder('')}
-                        title={t('sidebar.useDefaultLocation')}
-                        style={{ flexShrink: 0, fontSize: 11, color: 'var(--text-muted)', cursor: 'pointer' }}
-                      >×</span>
-                    </div>
-                  )}
-                </div>
-              ) : (
-                <button
-                  onClick={() => setCreatingProfile(true)}
-                  style={{
-                    display: 'flex', alignItems: 'center', gap: 6, width: '100%',
-                    padding: '6px 4px', background: 'transparent', border: 'none',
-                    color: 'var(--text-muted)', fontSize: 12, cursor: 'pointer',
-                  }}
-                  onMouseEnter={e => { e.currentTarget.style.color = 'var(--text-secondary)' }}
-                  onMouseLeave={e => { e.currentTarget.style.color = 'var(--text-muted)' }}
-                >
-                  <Plus size={11} /> New profile
-                </button>
-              )}
+              <button
+                onClick={() => { setProfileOpen(false); setShowNewProfileModal(true) }}
+                style={{
+                  display: 'flex', alignItems: 'center', gap: 6, width: '100%',
+                  padding: '6px 4px', background: 'transparent', border: 'none',
+                  color: 'var(--text-muted)', fontSize: 12, cursor: 'pointer',
+                }}
+                onMouseEnter={e => { e.currentTarget.style.color = 'var(--text-secondary)' }}
+                onMouseLeave={e => { e.currentTarget.style.color = 'var(--text-muted)' }}
+              >
+                <Plus size={11} /> New profile
+              </button>
             </div>
           </div>,
           document.body
         )}
       </div>
+
+      <NewProfileModal
+        open={showNewProfileModal}
+        onClose={() => setShowNewProfileModal(false)}
+        onCreated={handleProfileCreated}
+      />
 
       <nav className="sidebar-nav" aria-label="Main navigation">
         {sections.map(section => (

--- a/wails-app/frontend/src/components/Sidebar.render.test.jsx
+++ b/wails-app/frontend/src/components/Sidebar.render.test.jsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import Sidebar from './Sidebar.jsx'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key }),
+}))
+
+vi.mock('../wailsjs/go/main/App', () => ({
+  GetVersion: () => Promise.resolve({ version: '1.0.0' }),
+  GetHILItems: () => Promise.resolve([]),
+  GetProfiles: () => Promise.resolve([{ id: 'default', name: 'Default', is_active: true, root_dir: '', icon: '' }]),
+  SwitchProfile: () => Promise.resolve(),
+  ChooseProfileFolder: () => Promise.resolve(''),
+  MoveProfileFolder: () => Promise.resolve(),
+  RevealProfileFolder: () => Promise.resolve(),
+}))
+
+// Isolates this test from NewProfileModal's own implementation (covered by
+// NewProfileModal.render.test.jsx) -- only Sidebar's own decision to open it
+// is under test here.
+vi.mock('./NewProfileModal.jsx', () => ({
+  default: ({ open }) => (open ? <div data-testid="new-profile-modal">new profile modal open</div> : null),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+// Regression test for replacing the old inline "+ New profile" expand-in-
+// place row with a centered modal: clicking the profile switcher then
+// "+ New profile" must open NewProfileModal, not an inline form.
+it('opens the New Profile modal when "+ New profile" is clicked', async () => {
+  render(<Sidebar activePage="dashboard" onNavigate={() => {}} stats={{}} dbConnected={true} />)
+
+  await waitFor(() => expect(screen.getByText('Default')).toBeInTheDocument())
+
+  expect(screen.queryByTestId('new-profile-modal')).not.toBeInTheDocument()
+
+  fireEvent.click(screen.getByText('Default'))
+  fireEvent.click(screen.getByText('New profile'))
+
+  expect(screen.getByTestId('new-profile-modal')).toBeInTheDocument()
+})

--- a/wails-app/frontend/src/locales/en.json
+++ b/wails-app/frontend/src/locales/en.json
@@ -23,10 +23,18 @@
       "SYSTEM": "SYSTEM"
     },
     "showInFinder": "Show in Finder",
-    "changeProfileFolder": "Change profile folder location",
-    "profileNamePlaceholder": "Profile name…",
-    "chooseFolder": "Choose folder",
-    "useDefaultLocation": "Use default location"
+    "changeProfileFolder": "Change profile folder location"
+  },
+  "newProfileModal": {
+    "title": "New profile",
+    "chooseIcon": "Choose an icon",
+    "namePlaceholder": "Profile name",
+    "suggestedProjects": "Suggested from monomind projects",
+    "chooseDifferentFolder": "Choose a different folder…",
+    "useDefaultLocation": "Use the default location instead",
+    "cancel": "Cancel",
+    "create": "Create",
+    "creating": "Creating…"
   },
   "dashboard": {
     "title": "Dashboard",

--- a/wails-app/frontend/src/locales/es.json
+++ b/wails-app/frontend/src/locales/es.json
@@ -23,10 +23,18 @@
       "SYSTEM": "SISTEMA"
     },
     "showInFinder": "Mostrar en Finder",
-    "changeProfileFolder": "Cambiar la ubicación de la carpeta del perfil",
-    "profileNamePlaceholder": "Nombre del perfil…",
-    "chooseFolder": "Elegir carpeta",
-    "useDefaultLocation": "Usar ubicación predeterminada"
+    "changeProfileFolder": "Cambiar la ubicación de la carpeta del perfil"
+  },
+  "newProfileModal": {
+    "title": "Nuevo perfil",
+    "chooseIcon": "Elegir un ícono",
+    "namePlaceholder": "Nombre del perfil",
+    "suggestedProjects": "Sugerencias de proyectos monomind",
+    "chooseDifferentFolder": "Elegir otra carpeta…",
+    "useDefaultLocation": "Usar la ubicación predeterminada",
+    "cancel": "Cancelar",
+    "create": "Crear",
+    "creating": "Creando…"
   },
   "dashboard": {
     "title": "Panel",

--- a/wails-app/frontend/src/wailsjs/go/main/App.d.ts
+++ b/wails-app/frontend/src/wailsjs/go/main/App.d.ts
@@ -49,7 +49,7 @@ export function ConnectPlatformOAuth(arg1:string):Promise<string>;
 
 export function CreateOrgDesign(arg1:string):Promise<string>;
 
-export function CreateProfile(arg1:string,arg2:string):Promise<main.ProfileInfo>;
+export function CreateProfile(arg1:string,arg2:string,arg3:string):Promise<main.ProfileInfo>;
 
 export function CreateResource(arg1:string,arg2:string,arg3:string,arg4:string):Promise<main.ResourceItemResult>;
 
@@ -222,6 +222,8 @@ export function ListChatSessions(arg1:string):Promise<string>;
 export function ListConnections(arg1:string):Promise<Array<connections.SafeConnection>>;
 
 export function ListCredentialsForNode(arg1:string):Promise<Array<main.CredentialOption>>;
+
+export function ListMonomindProjects():Promise<Array<main.MonomindProjectInfo>>;
 
 export function ListOrgDesigns():Promise<string>;
 

--- a/wails-app/frontend/src/wailsjs/go/main/App.js
+++ b/wails-app/frontend/src/wailsjs/go/main/App.js
@@ -90,8 +90,8 @@ export function CreateOrgDesign(arg1) {
   return window['go']['main']['App']['CreateOrgDesign'](arg1);
 }
 
-export function CreateProfile(arg1, arg2) {
-  return window['go']['main']['App']['CreateProfile'](arg1, arg2);
+export function CreateProfile(arg1, arg2, arg3) {
+  return window['go']['main']['App']['CreateProfile'](arg1, arg2, arg3);
 }
 
 export function CreateResource(arg1, arg2, arg3, arg4) {
@@ -436,6 +436,10 @@ export function ListConnections(arg1) {
 
 export function ListCredentialsForNode(arg1) {
   return window['go']['main']['App']['ListCredentialsForNode'](arg1);
+}
+
+export function ListMonomindProjects() {
+  return window['go']['main']['App']['ListMonomindProjects']();
 }
 
 export function ListOrgDesigns() {

--- a/wails-app/frontend/src/wailsjs/go/models.ts
+++ b/wails-app/frontend/src/wailsjs/go/models.ts
@@ -391,6 +391,20 @@ export namespace main {
 	        this.message = source["message"];
 	    }
 	}
+	export class MonomindProjectInfo {
+	    path: string;
+	    name: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new MonomindProjectInfo(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.path = source["path"];
+	        this.name = source["name"];
+	    }
+	}
 	export class NodeRunOutput {
 	    handle: string;
 	    items: any[];
@@ -681,6 +695,7 @@ export namespace main {
 	    is_active: boolean;
 	    created_at: string;
 	    root_dir: string;
+	    icon: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new ProfileInfo(source);
@@ -693,6 +708,7 @@ export namespace main {
 	        this.is_active = source["is_active"];
 	        this.created_at = source["created_at"];
 	        this.root_dir = source["root_dir"];
+	        this.icon = source["icon"];
 	    }
 	}
 	export class ResourceItem {


### PR DESCRIPTION
## Summary
- Replace the inline "+ New profile" expand form with a centered modal: name field, icon picker (reuses the org designer's `IconPickerModal`), and a list of existing monomind-initialized projects to pick from — selecting one sets both the profile's name and root directory.
- Everything monoagent itself owns (vault images and documents) now lives under `<root>/.monoagent/vault/` instead of a bare `<root>/vault/`, with a `.monoagent/.gitignore` written automatically so it disappears as a single unit when `root_dir` points at a real repo. Existing profiles are migrated in place on every startup, idempotently.
- Fixes an unrelated gitignore gap: `.monomind/graph/.rebuild-lock` (a transient lock file the existing `.monomind/` audit patterns didn't catch).

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean on both the root and `wails-app` modules
- [x] `go test ./...` green on both modules, including new coverage for: the icon column reconcile, the `.monoagent/vault` migration (images + documents), a document-filename-collision regression test, and the `.monoagent/.gitignore` write/no-overwrite behavior
- [x] `npx vitest run` green (101 tests) in `wails-app/frontend`, including new coverage for `NewProfileModal` and the Sidebar's "+ New profile" wiring
- [x] Verified against the real local `~/.monoagent/monoagent.db` (read-only): confirms the migration is a safe no-op for all existing data
- [ ] Manual: in `wails dev`, open the profile switcher → "+ New profile" and confirm the modal, project suggestions, and icon picker render and work as expected (not independently verified in this environment — no GUI access)

## Known pre-existing bug (not touched by this PR)
`wails-app/main.go`'s `vaultImageHandler` serves vault images from a hardcoded legacy global path (`~/.monoagent/vault`) instead of the per-profile vault dir — broken for any profile using its own vault folder since before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHMRQmj4cHe2KrGcBpd3iw